### PR TITLE
feat: Tensor implementation in Cairo 1.0

### DIFF
--- a/src/lib.cairo
+++ b/src/lib.cairo
@@ -1,3 +1,4 @@
 mod performance;
 mod operators;
 mod tests;
+mod utils;

--- a/src/operators/math/tensor.cairo
+++ b/src/operators/math/tensor.cairo
@@ -1,33 +1,3 @@
-use array::ArrayTrait;
-use option::OptionTrait;
-
-use onnx_cairo::operators::math::int33;
-use onnx_cairo::operators::math::int33::i33;
-use onnx_cairo::operators::math::matrix::Matrix;
-use onnx_cairo::operators::math::matrix::MatrixTrait;
-
-impl Arrayi33Drop of Drop::<Array::<i33>>;
-
-// #[derive(Drop)]
-struct Tensor {
-    rows: usize,
-    cols: usize,
-    depth: usize,
-    data: Array::<Matrix>,
-}
-
-trait TensorTrait {
-    fn new(rows: usize, cols: usize, depth: usize, data: Array::<Matrix>) -> Tensor;
-}
-
-impl TensorImpl of TensorTrait {
-    #[inline(always)]
-    fn new(rows: usize, cols: usize, depth: usize, data: Array::<Matrix>) -> Tensor {
-        assert(data.len() == rows * cols * depth, 'Tensor not match dimensions');
-        tensor_new(rows, cols, depth, data)
-    }
-}
-
-fn tensor_new(rows: usize, cols: usize, depth: usize, data: Array::<Matrix>) -> Tensor {
-    Tensor { rows: rows, cols: cols, depth: depth, data: data,  }
-}
+mod core;
+mod tensor_i33;
+mod helpers;

--- a/src/operators/math/tensor/core.cairo
+++ b/src/operators/math/tensor/core.cairo
@@ -20,7 +20,6 @@ trait TensorTrait<T> {
     fn stride(self: @Tensor<T>) -> Array<usize>;
     fn ravel_index(self: @Tensor<T>, indices: @Array<usize>) -> usize;
     fn unravel_index(self: @Tensor<T>, index: usize) -> Array<usize>;
-    fn broadcast_index_mapping(self: @Tensor<T>, indices: @Array<usize>) -> usize;
 }
 
 // --- RAVEL ---
@@ -65,29 +64,6 @@ fn __unravel_index(
 
     result.append(coord);
     __unravel_index(remainder, shape, ref result, current_dim + 1_usize);
-}
-
-// --- BROADCAST INDEX MAPPING ---
-
-fn broadcast_index_mapping(shape: @Array<usize>, indices: @Array<usize>) -> usize {
-    let mut result = 0_usize;
-    __broadcast_index_mapping(shape, indices, ref result, 0_usize);
-
-    return result;
-}
-
-fn __broadcast_index_mapping(
-    shape: @Array<usize>, indices: @Array<usize>, ref result: usize, n: usize, 
-) {
-    check_gas();
-    if n == shape.len() {
-        return ();
-    }
-
-    let stride = stride(shape);
-    let index = (*indices.at(n) % *shape.at(n)) * *stride.at(n);
-    result += index;
-    __broadcast_index_mapping(shape, indices, ref result, n + 1_usize)
 }
 
 // --- STRIDE ---

--- a/src/operators/math/tensor/core.cairo
+++ b/src/operators/math/tensor/core.cairo
@@ -1,0 +1,117 @@
+use array::ArrayTrait;
+use option::OptionTrait;
+
+use onnx_cairo::utils::check_gas;
+use onnx_cairo::operators::math::tensor::helpers::len_from_shape;
+
+struct Tensor<T> {
+    shape: @Array<usize>,
+    data: @Array<T>
+}
+
+impl TensorCopy<T> of Copy::<Tensor::<T>>;
+impl TensorDrop<T> of Drop::<Tensor::<T>>;
+
+trait TensorTrait<T> {
+    fn new(shape: @Array<usize>, data: @Array<T>) -> Tensor<T>;
+    fn at(self: @Tensor<T>, indices: @Array<usize>) -> T;
+    fn min(self: @Tensor<T>) -> T;
+    fn max(self: @Tensor<T>) -> T;
+    fn stride(self: @Tensor<T>) -> Array<usize>;
+    fn ravel_index(self: @Tensor<T>, indices: @Array<usize>) -> usize;
+    fn unravel_index(self: @Tensor<T>, index: usize) -> Array<usize>;
+    fn broadcast_index_mapping(self: @Tensor<T>, indices: @Array<usize>) -> usize;
+    // Broadcast element-wise operations
+    fn add(self: @Tensor<T>, other: @Tensor<T>) -> Tensor<T>;
+    fn sub(self: @Tensor<T>, other: @Tensor<T>) -> Tensor<T>;
+    fn mul(self: @Tensor<T>, other: @Tensor<T>) -> Tensor<T>;
+    fn div(self: @Tensor<T>, other: @Tensor<T>) -> Tensor<T>;
+}
+
+// --- RAVEL ---
+
+fn ravel_index(shape: @Array<usize>, indices: @Array<usize>) -> usize {
+    __ravel_index(shape, indices, 0_usize)
+}
+
+
+fn __ravel_index(shape: @Array<usize>, indices: @Array<usize>, current_dim: usize) -> usize {
+    check_gas();
+    if current_dim == shape.len() - 1_usize {
+        return *indices.at(current_dim);
+    }
+
+    let first_dim_elements = len_from_shape(shape, current_dim + 1_usize);
+    let index = *indices.at(current_dim) * first_dim_elements;
+    return index + __ravel_index(shape, indices, current_dim + 1_usize);
+}
+
+// --- UNRAVEL ---
+
+fn unravel_index(index: usize, shape: @Array<usize>) -> Array<usize> {
+    let mut result = ArrayTrait::new();
+    __unravel_index(index, shape, ref result, 0_usize);
+    return result;
+}
+
+fn __unravel_index(
+    index: usize, shape: @Array<usize>, ref result: Array<usize>, current_dim: usize
+) {
+    check_gas();
+    if current_dim == shape.len()
+        - 1_usize {
+            result.append(index % *shape.at(current_dim));
+            return ();
+        }
+
+    let first_dim_elements = len_from_shape(shape, current_dim + 1_usize);
+    let coord = index / first_dim_elements;
+    let remainder = index % first_dim_elements;
+
+    result.append(coord);
+    __unravel_index(remainder, shape, ref result, current_dim + 1_usize);
+}
+
+// --- BROADCAST INDEX MAPPING ---
+
+fn broadcast_index_mapping(shape: @Array<usize>, indices: @Array<usize>) -> usize {
+    let mut result = 0_usize;
+    __broadcast_index_mapping(shape, indices, ref result, 0_usize);
+
+    return result;
+}
+
+fn __broadcast_index_mapping(
+    shape: @Array<usize>, indices: @Array<usize>, ref result: usize, n: usize, 
+) {
+    check_gas();
+    if n == shape.len() {
+        return ();
+    }
+
+    let stride = stride(shape);
+    let index = (*indices.at(n) % *shape.at(n)) * *stride.at(n);
+    result += index;
+    __broadcast_index_mapping(shape, indices, ref result, n + 1_usize)
+}
+
+// --- STRIDE ---
+
+fn stride(shape: @Array<usize>) -> Array<usize> {
+    let mut result = ArrayTrait::new();
+    __stride(shape, ref result, shape.len() - 1_usize, 1_usize);
+    return result;
+}
+
+fn __stride(shape: @Array<usize>, ref result: Array<usize>, n: usize, accumulated: usize) {
+    check_gas();
+
+    if n == 0_usize {
+        result.append(accumulated);
+        return ();
+    }
+
+    let new_accumulated = accumulated * *shape.at(n);
+    __stride(shape, ref result, n - 1_usize, new_accumulated);
+    result.append(accumulated);
+}

--- a/src/operators/math/tensor/core.cairo
+++ b/src/operators/math/tensor/core.cairo
@@ -21,11 +21,6 @@ trait TensorTrait<T> {
     fn ravel_index(self: @Tensor<T>, indices: @Array<usize>) -> usize;
     fn unravel_index(self: @Tensor<T>, index: usize) -> Array<usize>;
     fn broadcast_index_mapping(self: @Tensor<T>, indices: @Array<usize>) -> usize;
-    // Broadcast element-wise operations
-    fn add(self: @Tensor<T>, other: @Tensor<T>) -> Tensor<T>;
-    fn sub(self: @Tensor<T>, other: @Tensor<T>) -> Tensor<T>;
-    fn mul(self: @Tensor<T>, other: @Tensor<T>) -> Tensor<T>;
-    fn div(self: @Tensor<T>, other: @Tensor<T>) -> Tensor<T>;
 }
 
 // --- RAVEL ---

--- a/src/operators/math/tensor/helpers.cairo
+++ b/src/operators/math/tensor/helpers.cairo
@@ -2,6 +2,7 @@ use array::ArrayTrait;
 use option::OptionTrait;
 
 use onnx_cairo::utils::check_gas;
+use onnx_cairo::operators::math::tensor::core::stride;
 
 
 fn len_from_shape(shape: @Array<usize>, index: usize) -> usize {
@@ -34,4 +35,25 @@ fn check_compatibility(shape_1: @Array<usize>, shape_2: @Array<usize>, index: us
     );
 
     check_compatibility(shape_1, shape_2, index + 1_usize);
+}
+
+fn broadcast_index_mapping(shape: @Array<usize>, indices: @Array<usize>) -> usize {
+    let mut result = 0_usize;
+    __broadcast_index_mapping(shape, indices, ref result, 0_usize);
+
+    return result;
+}
+
+fn __broadcast_index_mapping(
+    shape: @Array<usize>, indices: @Array<usize>, ref result: usize, n: usize, 
+) {
+    check_gas();
+    if n == shape.len() {
+        return ();
+    }
+
+    let stride = stride(shape);
+    let index = (*indices.at(n) % *shape.at(n)) * *stride.at(n);
+    result += index;
+    __broadcast_index_mapping(shape, indices, ref result, n + 1_usize)
 }

--- a/src/operators/math/tensor/helpers.cairo
+++ b/src/operators/math/tensor/helpers.cairo
@@ -1,0 +1,37 @@
+use array::ArrayTrait;
+use option::OptionTrait;
+
+use onnx_cairo::utils::check_gas;
+
+
+fn len_from_shape(shape: @Array<usize>, index: usize) -> usize {
+    check_gas();
+    if (index == shape.len()
+        - 1_usize) {
+            return *shape.at(index);
+        } else {
+            return *shape.at(index) * len_from_shape(shape, index + 1_usize);
+        }
+}
+
+fn check_shape<T>(shape: @Array<usize>, data: @Array<T>) {
+    assert(len_from_shape(shape, 0_usize) == data.len(), 'wrong tensor shape');
+}
+
+fn check_compatibility(shape_1: @Array<usize>, shape_2: @Array<usize>, index: usize) {
+    check_gas();
+    assert(shape_1.len() == shape_2.len(), 'tensors shape must match');
+
+    if index == shape_1.len() {
+        return ();
+    }
+
+    assert(
+        *shape_1.at(
+            index
+        ) == *shape_2.at(index) | *shape_1.at(index) == 1_usize | *shape_2.at(index) == 1_usize,
+        'tensors shape must match'
+    );
+
+    check_compatibility(shape_1, shape_2, index + 1_usize);
+}

--- a/src/operators/math/tensor/tensor_i33.cairo
+++ b/src/operators/math/tensor/tensor_i33.cairo
@@ -46,21 +46,29 @@ impl I33Tensor of TensorTrait::<i33> {
     fn broadcast_index_mapping(self: @Tensor<i33>, indices: @Array<usize>) -> usize {
         broadcast_index_mapping(*self.shape, indices)
     }
+}
 
-    fn add(self: @Tensor<i33>, other: @Tensor<i33>) -> Tensor<i33> {
-        i33_add_tensor(self, other)
+impl i33TensorAdd of Add::<Tensor<i33>> {
+    fn add(self: Tensor<i33>, other: Tensor<i33>) -> Tensor<i33> {
+        i33_add_tensor(@self, @other)
     }
+}
 
-    fn sub(self: @Tensor<i33>, other: @Tensor<i33>) -> Tensor<i33> {
-        i33_sub_tensor(self, other)
+impl i33TensorSub of Sub::<Tensor<i33>> {
+    fn sub(self: Tensor<i33>, other: Tensor<i33>) -> Tensor<i33> {
+        i33_sub_tensor(@self, @other)
     }
+}
 
-    fn mul(self: @Tensor<i33>, other: @Tensor<i33>) -> Tensor<i33> {
-        i33_mul_tensor(self, other)
+impl i33TensorMul of Mul::<Tensor<i33>> {
+    fn mul(self: Tensor<i33>, other: Tensor<i33>) -> Tensor<i33> {
+        i33_mul_tensor(@self, @other)
     }
+}
 
-    fn div(self: @Tensor<i33>, other: @Tensor<i33>) -> Tensor<i33> {
-        i33_div_tensor(self, other)
+impl i33TensorDiv of Div::<Tensor<i33>> {
+    fn div(self: Tensor<i33>, other: Tensor<i33>) -> Tensor<i33> {
+        i33_div_tensor(@self, @other)
     }
 }
 

--- a/src/operators/math/tensor/tensor_i33.cairo
+++ b/src/operators/math/tensor/tensor_i33.cairo
@@ -1,0 +1,211 @@
+use array::ArrayTrait;
+use option::OptionTrait;
+
+use onnx_cairo::operators::math::int33;
+use onnx_cairo::operators::math::int33::i33;
+use onnx_cairo::operators::math::tensor::helpers::check_shape;
+use onnx_cairo::operators::math::tensor::helpers::check_compatibility;
+use onnx_cairo::operators::math::tensor::core::stride;
+use onnx_cairo::operators::math::tensor::core::Tensor;
+use onnx_cairo::operators::math::tensor::core::TensorTrait;
+use onnx_cairo::operators::math::tensor::core::len_from_shape;
+use onnx_cairo::operators::math::tensor::core::ravel_index;
+use onnx_cairo::operators::math::tensor::core::unravel_index;
+use onnx_cairo::operators::math::tensor::core::broadcast_index_mapping;
+use onnx_cairo::utils::check_gas;
+
+impl I33Tensor of TensorTrait::<i33> {
+    fn new(shape: @Array<usize>, data: @Array<i33>) -> Tensor<i33> {
+        i33_new_tensor(shape, data)
+    }
+
+    fn at(self: @Tensor<i33>, indices: @Array<usize>) -> i33 {
+        i33_at_tensor(self, indices)
+    }
+
+    fn min(self: @Tensor<i33>) -> i33 {
+        i33_min_tensor(*self.data)
+    }
+
+    fn max(self: @Tensor<i33>) -> i33 {
+        i33_max_tensor(*self.data)
+    }
+
+    fn stride(self: @Tensor<i33>) -> Array<usize> {
+        stride(*self.shape)
+    }
+
+    fn ravel_index(self: @Tensor<i33>, indices: @Array<usize>) -> usize {
+        ravel_index(*self.shape, indices)
+    }
+
+    fn unravel_index(self: @Tensor<i33>, index: usize) -> Array<usize> {
+        unravel_index(index, *self.shape)
+    }
+
+    fn broadcast_index_mapping(self: @Tensor<i33>, indices: @Array<usize>) -> usize {
+        broadcast_index_mapping(*self.shape, indices)
+    }
+
+    fn add(self: @Tensor<i33>, other: @Tensor<i33>) -> Tensor<i33> {
+        i33_add_tensor(self, other)
+    }
+
+    fn sub(self: @Tensor<i33>, other: @Tensor<i33>) -> Tensor<i33> {
+        i33_sub_tensor(self, other)
+    }
+
+    fn mul(self: @Tensor<i33>, other: @Tensor<i33>) -> Tensor<i33> {
+        i33_mul_tensor(self, other)
+    }
+
+    fn div(self: @Tensor<i33>, other: @Tensor<i33>) -> Tensor<i33> {
+        i33_div_tensor(self, other)
+    }
+}
+
+fn i33_new_tensor(shape: @Array<usize>, data: @Array<i33>) -> Tensor<i33> {
+    check_shape::<i33>(shape, data);
+    Tensor::<i33> { shape, data }
+}
+
+#[inline(always)]
+fn i33_at_tensor(self: @Tensor<i33>, indices: @Array<usize>) -> i33 {
+    let data = *self.data;
+    *data.at(self.ravel_index(indices))
+}
+
+fn i33_min_tensor(vec: @Array::<i33>) -> i33 {
+    let mut min_value = i33 { inner: 65535_u32, sign: false };
+    __i33_min_tensor(vec, ref min_value, 0_usize);
+    return min_value;
+}
+
+fn __i33_min_tensor(vec: @Array::<i33>, ref min_value: i33, n: usize) {
+    check_gas();
+    if n == vec.len() {
+        return ();
+    }
+
+    let check_min = int33::min(min_value, *vec.at(n));
+    if (min_value > check_min) {
+        min_value = check_min;
+    }
+
+    __i33_min_tensor(vec, ref min_value, n + 1_usize);
+}
+
+fn i33_max_tensor(vec: @Array::<i33>) -> i33 {
+    let mut max_value = i33 { inner: 0_u32, sign: false };
+    __i33_max_tensor(vec, ref max_value, 0_usize);
+    return max_value;
+}
+
+fn __i33_max_tensor(vec: @Array::<i33>, ref max_value: i33, n: usize) {
+    check_gas();
+    if n == vec.len() {
+        return ();
+    }
+
+    let check_max = int33::max(max_value, *vec.at(n));
+    if (max_value < check_max) {
+        max_value = check_max;
+    }
+
+    __i33_max_tensor(vec, ref max_value, n + 1_usize);
+}
+
+// --- BROADCAST OPERATIONS ---
+
+fn i33_add_tensor(self: @Tensor<i33>, other: @Tensor<i33>) -> Tensor<i33> {
+    check_compatibility(*self.shape, *other.shape, 0_usize);
+    let mut result = ArrayTrait::new();
+    __i33_add_tensor(self, other, ref result, 0_usize);
+    return TensorTrait::<i33>::new(*self.shape, @result);
+}
+
+fn __i33_add_tensor(self: @Tensor<i33>, other: @Tensor<i33>, ref result: Array::<i33>, n: usize) {
+    check_gas();
+    if n == (*self.data).len() {
+        return ();
+    }
+
+    let indices_self = self.unravel_index(n);
+    let indices_other = other.unravel_index(n);
+
+    let i = self.broadcast_index_mapping(@indices_self);
+    let j = other.broadcast_index_mapping(@indices_other);
+
+    result.append(*(*self.data).at(i) + *(*other.data).at(j));
+    __i33_add_tensor(self, other, ref result, n + 1_usize);
+}
+
+fn i33_sub_tensor(self: @Tensor<i33>, other: @Tensor<i33>) -> Tensor<i33> {
+    check_compatibility(*self.shape, *other.shape, 0_usize);
+    let mut result = ArrayTrait::new();
+    __i33_sub_tensor(self, other, ref result, 0_usize);
+    return TensorTrait::<i33>::new(*self.shape, @result);
+}
+
+fn __i33_sub_tensor(self: @Tensor<i33>, other: @Tensor<i33>, ref result: Array::<i33>, n: usize) {
+    check_gas();
+    if n == (*self.data).len() {
+        return ();
+    }
+
+    let indices_self = self.unravel_index(n);
+    let indices_other = other.unravel_index(n);
+
+    let i = self.broadcast_index_mapping(@indices_self);
+    let j = other.broadcast_index_mapping(@indices_other);
+
+    result.append(*(*self.data).at(i) - *(*other.data).at(j));
+    __i33_sub_tensor(self, other, ref result, n + 1_usize);
+}
+
+fn i33_mul_tensor(self: @Tensor<i33>, other: @Tensor<i33>) -> Tensor<i33> {
+    check_compatibility(*self.shape, *other.shape, 0_usize);
+    let mut result = ArrayTrait::new();
+    __i33_mul_tensor(self, other, ref result, 0_usize);
+    return TensorTrait::<i33>::new(*self.shape, @result);
+}
+
+fn __i33_mul_tensor(self: @Tensor<i33>, other: @Tensor<i33>, ref result: Array::<i33>, n: usize) {
+    check_gas();
+    if n == (*self.data).len() {
+        return ();
+    }
+
+    let indices_self = self.unravel_index(n);
+    let indices_other = other.unravel_index(n);
+
+    let i = self.broadcast_index_mapping(@indices_self);
+    let j = other.broadcast_index_mapping(@indices_other);
+
+    result.append(*(*self.data).at(i) * *(*other.data).at(j));
+    __i33_mul_tensor(self, other, ref result, n + 1_usize);
+}
+
+fn i33_div_tensor(self: @Tensor<i33>, other: @Tensor<i33>) -> Tensor<i33> {
+    check_compatibility(*self.shape, *other.shape, 0_usize);
+    let mut result = ArrayTrait::new();
+    __i33_div_tensor(self, other, ref result, 0_usize);
+    return TensorTrait::<i33>::new(*self.shape, @result);
+}
+
+fn __i33_div_tensor(self: @Tensor<i33>, other: @Tensor<i33>, ref result: Array::<i33>, n: usize) {
+    check_gas();
+    if n == (*self.data).len() {
+        return ();
+    }
+
+    let indices_self = self.unravel_index(n);
+    let indices_other = other.unravel_index(n);
+
+    let i = self.broadcast_index_mapping(@indices_self);
+    let j = other.broadcast_index_mapping(@indices_other);
+
+    result.append(*(*self.data).at(i) / *(*other.data).at(j));
+    __i33_div_tensor(self, other, ref result, n + 1_usize);
+}
+

--- a/src/operators/math/tensor/tensor_i33.cairo
+++ b/src/operators/math/tensor/tensor_i33.cairo
@@ -8,43 +8,115 @@ use onnx_cairo::operators::math::tensor::helpers::check_compatibility;
 use onnx_cairo::operators::math::tensor::core::stride;
 use onnx_cairo::operators::math::tensor::core::Tensor;
 use onnx_cairo::operators::math::tensor::core::TensorTrait;
-use onnx_cairo::operators::math::tensor::core::len_from_shape;
 use onnx_cairo::operators::math::tensor::core::ravel_index;
 use onnx_cairo::operators::math::tensor::core::unravel_index;
-use onnx_cairo::operators::math::tensor::core::broadcast_index_mapping;
+use onnx_cairo::operators::math::tensor::helpers::broadcast_index_mapping;
 use onnx_cairo::utils::check_gas;
 
 impl I33Tensor of TensorTrait::<i33> {
+    /// Creates tensor.
+    ///
+    /// # Arguments
+    ///
+    /// * `shape` - A reference to an array of usizes representing the shape of the tensor.
+    /// * `data` -  A reference to an array of i33 reprensenting the data of the tensor as flat array.
+    ///
+    /// # Returns
+    ///
+    /// The tensor.
+    ///
+    /// # Panics
+    ///
+    /// Panic if the shape of the matrix does not match the size of the data array.
     fn new(shape: @Array<usize>, data: @Array<i33>) -> Tensor<i33> {
         i33_new_tensor(shape, data)
     }
 
+    /// Returns the value of a particular element in the matrix.
+    ///
+    /// # Arguments
+    ///
+    /// * `self` - A reference to the tensor.
+    /// * `indices` - The indices of the element.
+    ///
+    /// # Returns
+    ///
+    /// The value of the element at the specified indices.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the indices are out of bounds.
     fn at(self: @Tensor<i33>, indices: @Array<usize>) -> i33 {
         i33_at_tensor(self, indices)
     }
 
+    /// Returns the minimum value in the tensor.
+    ///
+    /// # Arguments
+    ///
+    /// * `self` - A reference to the tensor.
+    ///
+    /// # Returns
+    ///
+    /// The minimum value in tensor.
+    // TODO: find minimum by axis
     fn min(self: @Tensor<i33>) -> i33 {
         i33_min_tensor(*self.data)
     }
 
+    /// Returns the maximum value in the tensor.
+    ///
+    /// # Arguments
+    ///
+    /// * `self` - A reference to the tensor.
+    ///
+    /// # Returns
+    ///
+    /// The maximum value in tensor.
+    // TODO: find maximum by axis
     fn max(self: @Tensor<i33>) -> i33 {
         i33_max_tensor(*self.data)
     }
 
+    /// Returns the stride of a tensor.
+    ///
+    /// # Arguments
+    ///
+    /// * `self` - A reference to the tensor.
+    ///
+    /// # Returns
+    ///
+    /// the stride of a tensor.
     fn stride(self: @Tensor<i33>) -> Array<usize> {
         stride(*self.shape)
     }
 
+    /// Returns the flat index corresponding to an array of indices.
+    ///
+    /// # Arguments
+    ///
+    /// * `self` - A reference to the tensor.
+    /// * `indices` - A reference to the indices.
+    ///
+    /// # Returns
+    ///
+    /// the flat index corresponding to an array of indices.
     fn ravel_index(self: @Tensor<i33>, indices: @Array<usize>) -> usize {
         ravel_index(*self.shape, indices)
     }
 
+    /// Returns the array of indices corresponding to a flat index.
+    ///
+    /// # Arguments
+    ///
+    /// * `self` - A reference to the tensor.
+    /// * `indices` - A reference to the indices.
+    ///
+    /// # Returns
+    ///
+    /// the array of indices corresponding to a flat index.
     fn unravel_index(self: @Tensor<i33>, index: usize) -> Array<usize> {
         unravel_index(index, *self.shape)
-    }
-
-    fn broadcast_index_mapping(self: @Tensor<i33>, indices: @Array<usize>) -> usize {
-        broadcast_index_mapping(*self.shape, indices)
     }
 }
 
@@ -141,8 +213,8 @@ fn __i33_add_tensor(self: @Tensor<i33>, other: @Tensor<i33>, ref result: Array::
     let indices_self = self.unravel_index(n);
     let indices_other = other.unravel_index(n);
 
-    let i = self.broadcast_index_mapping(@indices_self);
-    let j = other.broadcast_index_mapping(@indices_other);
+    let i = broadcast_index_mapping(*self.shape, @indices_self);
+    let j = broadcast_index_mapping(*other.shape, @indices_other);
 
     result.append(*(*self.data).at(i) + *(*other.data).at(j));
     __i33_add_tensor(self, other, ref result, n + 1_usize);
@@ -164,8 +236,8 @@ fn __i33_sub_tensor(self: @Tensor<i33>, other: @Tensor<i33>, ref result: Array::
     let indices_self = self.unravel_index(n);
     let indices_other = other.unravel_index(n);
 
-    let i = self.broadcast_index_mapping(@indices_self);
-    let j = other.broadcast_index_mapping(@indices_other);
+    let i = broadcast_index_mapping(*self.shape, @indices_self);
+    let j = broadcast_index_mapping(*other.shape, @indices_other);
 
     result.append(*(*self.data).at(i) - *(*other.data).at(j));
     __i33_sub_tensor(self, other, ref result, n + 1_usize);
@@ -187,8 +259,8 @@ fn __i33_mul_tensor(self: @Tensor<i33>, other: @Tensor<i33>, ref result: Array::
     let indices_self = self.unravel_index(n);
     let indices_other = other.unravel_index(n);
 
-    let i = self.broadcast_index_mapping(@indices_self);
-    let j = other.broadcast_index_mapping(@indices_other);
+    let i = broadcast_index_mapping(*self.shape, @indices_self);
+    let j = broadcast_index_mapping(*other.shape, @indices_other);
 
     result.append(*(*self.data).at(i) * *(*other.data).at(j));
     __i33_mul_tensor(self, other, ref result, n + 1_usize);
@@ -210,8 +282,8 @@ fn __i33_div_tensor(self: @Tensor<i33>, other: @Tensor<i33>, ref result: Array::
     let indices_self = self.unravel_index(n);
     let indices_other = other.unravel_index(n);
 
-    let i = self.broadcast_index_mapping(@indices_self);
-    let j = other.broadcast_index_mapping(@indices_other);
+    let i = broadcast_index_mapping(*self.shape, @indices_self);
+    let j = broadcast_index_mapping(*other.shape, @indices_other);
 
     result.append(*(*self.data).at(i) / *(*other.data).at(j));
     __i33_div_tensor(self, other, ref result, n + 1_usize);

--- a/src/tests.cairo
+++ b/src/tests.cairo
@@ -5,4 +5,5 @@ mod int33_test;
 mod quantization_test;
 mod relu_test;
 mod vector_test;
+mod tensor_test;
 // mod softmax_test;

--- a/src/tests/tensor_test.cairo
+++ b/src/tests/tensor_test.cairo
@@ -165,7 +165,7 @@ fn i33_add_tensor() {
     let tensor_1 = i33_tensor_helper();
     let tensor_2 = i33_tensor_helper();
 
-    let result = tensor_1.add(@tensor_2).data;
+    let result = (tensor_1 + tensor_2).data;
 
     assert(*result.at(0_usize).inner == 0_u32, 'result[0] = 0');
     assert(*result.at(1_usize).inner == 2_u32, 'result[1] = 2');
@@ -187,7 +187,7 @@ fn i33_add_tensor() {
     data.append(i33 { inner: 100_u32, sign: false });
     let tensor_2 = TensorTrait::<i33>::new(@sizes, @data);
 
-    let result = tensor_1.add(@tensor_2).data;
+    let result = (tensor_1 + tensor_2).data;
 
     assert(*result.at(0_usize).inner == 10_u32, 'result[0] = 10');
     assert(*result.at(1_usize).inner == 101_u32, 'result[1] = 101');
@@ -205,7 +205,7 @@ fn i33_sub_tensor() {
     let tensor_1 = i33_tensor_helper();
     let tensor_2 = i33_tensor_helper();
 
-    let result = tensor_1.sub(@tensor_2).data;
+    let result = (tensor_1 - tensor_2).data;
 
     assert(*result.at(0_usize).inner == 0_u32, 'result[0] = 0');
     assert(*result.at(1_usize).inner == 0_u32, 'result[1] = 0');
@@ -227,7 +227,7 @@ fn i33_sub_tensor() {
     data.append(i33 { inner: 1_u32, sign: false });
     let tensor_2 = TensorTrait::<i33>::new(@sizes, @data);
 
-    let result = tensor_1.sub(@tensor_2).data;
+    let result = (tensor_1 - tensor_2).data;
 
     assert(*result.at(0_usize).inner == 0_u32, 'result[0] = 0');
     assert(*result.at(1_usize).inner == 0_u32, 'result[1] = 0');
@@ -245,7 +245,7 @@ fn i33_mul_tensor() {
     let tensor_1 = i33_tensor_helper();
     let tensor_2 = i33_tensor_helper();
 
-    let result = tensor_1.mul(@tensor_2).data;
+    let result = (tensor_1 * tensor_2).data;
 
     assert(*result.at(0_usize).inner == 0_u32, 'result[0] = 0');
     assert(*result.at(1_usize).inner == 1_u32, 'result[1] = 1');
@@ -267,7 +267,7 @@ fn i33_mul_tensor() {
     data.append(i33 { inner: 100_u32, sign: false });
     let tensor_2 = TensorTrait::<i33>::new(@sizes, @data);
 
-    let result = tensor_1.mul(@tensor_2).data;
+    let result = (tensor_1 * tensor_2).data;
 
     assert(*result.at(0_usize).inner == 0_u32, 'result[0] = 0');
     assert(*result.at(1_usize).inner == 100_u32, 'result[1] = 100');
@@ -312,7 +312,7 @@ fn i33_div_tensor() {
     data.append(i33 { inner: 800_u32, sign: false });
     let tensor_2 = TensorTrait::<i33>::new(@sizes, @data);
 
-    let result = tensor_1.div(@tensor_2).data;
+    let result = (tensor_1 / tensor_2).data;
 
     assert(*result.at(0_usize).inner == 1_u32, 'result[0] = 1');
     assert(*result.at(1_usize).inner == 1_u32, 'result[1] = 1');
@@ -334,7 +334,7 @@ fn i33_div_tensor() {
     data.append(i33 { inner: 100_u32, sign: false });
     let tensor_2 = TensorTrait::<i33>::new(@sizes, @data);
 
-    let result = tensor_1.div(@tensor_2).data;
+    let result = (tensor_1 / tensor_2).data;
 
     assert(*result.at(0_usize).inner == 10_u32, 'result[0] = 10');
     assert(*result.at(1_usize).inner == 2_u32, 'result[1] = 2');

--- a/src/tests/tensor_test.cairo
+++ b/src/tests/tensor_test.cairo
@@ -8,8 +8,6 @@ use onnx_cairo::operators::math::tensor::core::TensorTrait;
 use onnx_cairo::operators::math::tensor::core::Tensor;
 use onnx_cairo::operators::math::tensor::core::ravel_index;
 use onnx_cairo::operators::math::tensor::core::unravel_index;
-use onnx_cairo::operators::math::tensor::core::broadcast_index_mapping;
-
 
 #[test]
 #[available_gas(2000000)]

--- a/src/tests/tensor_test.cairo
+++ b/src/tests/tensor_test.cairo
@@ -1,0 +1,368 @@
+use array::ArrayTrait;
+use traits::Into;
+use debug::print_felt252;
+
+use onnx_cairo::operators::math::int33::i33;
+use onnx_cairo::operators::math::tensor::tensor_i33;
+use onnx_cairo::operators::math::tensor::core::TensorTrait;
+use onnx_cairo::operators::math::tensor::core::Tensor;
+use onnx_cairo::operators::math::tensor::core::ravel_index;
+use onnx_cairo::operators::math::tensor::core::unravel_index;
+use onnx_cairo::operators::math::tensor::core::broadcast_index_mapping;
+
+
+#[test]
+#[available_gas(2000000)]
+#[should_panic]
+fn i33_wrong_shape_tensor_test() {
+    let mut sizes = ArrayTrait::new();
+    sizes.append(2_usize);
+    sizes.append(2_usize);
+    sizes.append(2_usize);
+
+    let mut data = ArrayTrait::new();
+    data.append(i33 { inner: 0_u32, sign: false });
+    data.append(i33 { inner: 1_u32, sign: false });
+    data.append(i33 { inner: 2_u32, sign: false });
+
+    let tensor = TensorTrait::<i33>::new(@sizes, @data);
+}
+
+#[test]
+#[available_gas(2000000)]
+fn i33_at_tensor_test() {
+    let tensor = i33_tensor_helper();
+
+    let mut indices = ArrayTrait::new();
+    indices.append(0_usize);
+    indices.append(1_usize);
+    indices.append(1_usize);
+
+    let result = tensor.at(@indices).inner;
+
+    assert(result == 3_u32, 'result[3] = 3');
+}
+
+#[test]
+#[available_gas(2000000)]
+fn stride_test() {
+    let tensor = i33_tensor_helper();
+    let result = tensor.stride();
+    assert(*result.at(0_usize) == 4_usize, 'stride x = 4');
+    assert(*result.at(1_usize) == 2_usize, 'stride y = 2');
+    assert(*result.at(2_usize) == 1_usize, 'stride z = 1');
+}
+
+#[test]
+#[available_gas(2000000)]
+fn ravel_index_test() {
+    // 1D
+    let mut shape = ArrayTrait::new();
+    shape.append(5_usize);
+    let mut indices = ArrayTrait::new();
+    indices.append(2_usize);
+    let result = ravel_index(@shape, @indices);
+    assert(result == 2_usize, 'result = 2');
+
+    // 2D
+    let mut shape = ArrayTrait::new();
+    shape.append(2_usize);
+    shape.append(4_usize);
+    let mut indices = ArrayTrait::new();
+    indices.append(1_usize);
+    indices.append(2_usize);
+    let result = ravel_index(@shape, @indices);
+    assert(result == 6_usize, 'result = 6');
+
+    // 3D
+    let mut shape = ArrayTrait::new();
+    shape.append(2_usize);
+    shape.append(4_usize);
+    shape.append(6_usize);
+    let mut indices = ArrayTrait::new();
+    indices.append(1_usize);
+    indices.append(3_usize);
+    indices.append(0_usize);
+    let result = ravel_index(@shape, @indices);
+    assert(result == 42_usize, 'result = 42');
+
+    // 4D
+    let mut shape = ArrayTrait::new();
+    shape.append(2_usize);
+    shape.append(4_usize);
+    shape.append(6_usize);
+    shape.append(8_usize);
+    let mut indices = ArrayTrait::new();
+    indices.append(0_usize);
+    indices.append(2_usize);
+    indices.append(5_usize);
+    indices.append(6_usize);
+    let result = ravel_index(@shape, @indices);
+    assert(result == 142_usize, 'result = 142');
+}
+
+#[test]
+#[available_gas(2000000)]
+fn unravel_index_test() {
+    // 1D
+    let mut shape = ArrayTrait::new();
+    shape.append(5_usize);
+    let result = unravel_index(2_usize, @shape);
+    assert(*result.at(0_usize) == 2_usize, 'result[0] = 2');
+
+    // 2D
+    let mut shape = ArrayTrait::new();
+    shape.append(2_usize);
+    shape.append(4_usize);
+    let result = unravel_index(6_usize, @shape);
+    assert(*result.at(0_usize) == 1_usize, 'result[0] = 1');
+    assert(*result.at(1_usize) == 2_usize, 'result[1] = 2');
+
+    // 3D
+    let mut shape = ArrayTrait::new();
+    shape.append(2_usize);
+    shape.append(4_usize);
+    shape.append(6_usize);
+    let result = unravel_index(42_usize, @shape);
+    assert(*result.at(0_usize) == 1_usize, 'result[0] = 1');
+    assert(*result.at(1_usize) == 3_usize, 'result[1] = 3');
+    assert(*result.at(2_usize) == 0_usize, 'result[2] = 0');
+
+    // 4D
+    let mut shape = ArrayTrait::new();
+    shape.append(2_usize);
+    shape.append(4_usize);
+    shape.append(6_usize);
+    shape.append(8_usize);
+    let result = unravel_index(142_usize, @shape);
+    assert(*result.at(0_usize) == 0_usize, 'result[0] = 0');
+    assert(*result.at(1_usize) == 2_usize, 'result[1] = 2');
+    assert(*result.at(2_usize) == 5_usize, 'result[2] = 5');
+    assert(*result.at(3_usize) == 6_usize, 'result[3] = 6');
+}
+
+#[test]
+#[available_gas(2000000)]
+fn i33_min_tensor() {
+    let tensor = i33_tensor_helper();
+
+    let result = tensor.min().inner;
+    assert(result == 0_u32, 'tensor.min = 0');
+}
+
+#[test]
+#[available_gas(2000000)]
+fn i33_max_tensor() {
+    let tensor = i33_tensor_helper();
+
+    let result = tensor.max().inner;
+    assert(result == 7_u32, 'tensor.max = 7');
+}
+
+#[test]
+#[available_gas(20000000)]
+fn i33_add_tensor() {
+    let tensor_1 = i33_tensor_helper();
+    let tensor_2 = i33_tensor_helper();
+
+    let result = tensor_1.add(@tensor_2).data;
+
+    assert(*result.at(0_usize).inner == 0_u32, 'result[0] = 0');
+    assert(*result.at(1_usize).inner == 2_u32, 'result[1] = 2');
+    assert(*result.at(2_usize).inner == 4_u32, 'result[2] = 4');
+    assert(*result.at(3_usize).inner == 6_u32, 'result[3] = 6');
+    assert(*result.at(4_usize).inner == 8_u32, 'result[4] = 8');
+    assert(*result.at(5_usize).inner == 10_u32, 'result[5] = 10');
+    assert(*result.at(6_usize).inner == 12_u32, 'result[6] = 12');
+    assert(*result.at(7_usize).inner == 14_u32, 'result[7] = 14');
+
+    // broadcast operation 
+
+    let mut sizes = ArrayTrait::new();
+    sizes.append(1_usize);
+    sizes.append(2_usize);
+    sizes.append(1_usize);
+    let mut data = ArrayTrait::new();
+    data.append(i33 { inner: 10_u32, sign: false });
+    data.append(i33 { inner: 100_u32, sign: false });
+    let tensor_2 = TensorTrait::<i33>::new(@sizes, @data);
+
+    let result = tensor_1.add(@tensor_2).data;
+
+    assert(*result.at(0_usize).inner == 10_u32, 'result[0] = 10');
+    assert(*result.at(1_usize).inner == 101_u32, 'result[1] = 101');
+    assert(*result.at(2_usize).inner == 12_u32, 'result[2] = 12');
+    assert(*result.at(3_usize).inner == 103_u32, 'result[3] = 103');
+    assert(*result.at(4_usize).inner == 14_u32, 'result[4] = 14');
+    assert(*result.at(5_usize).inner == 105_u32, 'result[5] = 105');
+    assert(*result.at(6_usize).inner == 16_u32, 'result[6] = 16');
+    assert(*result.at(7_usize).inner == 107_u32, 'result[7] = 107');
+}
+
+#[test]
+#[available_gas(20000000)]
+fn i33_sub_tensor() {
+    let tensor_1 = i33_tensor_helper();
+    let tensor_2 = i33_tensor_helper();
+
+    let result = tensor_1.sub(@tensor_2).data;
+
+    assert(*result.at(0_usize).inner == 0_u32, 'result[0] = 0');
+    assert(*result.at(1_usize).inner == 0_u32, 'result[1] = 0');
+    assert(*result.at(2_usize).inner == 0_u32, 'result[2] = 0');
+    assert(*result.at(3_usize).inner == 0_u32, 'result[3] = 0');
+    assert(*result.at(4_usize).inner == 0_u32, 'result[4] = 0');
+    assert(*result.at(5_usize).inner == 0_u32, 'result[5] = 0');
+    assert(*result.at(6_usize).inner == 0_u32, 'result[6] = 0');
+    assert(*result.at(7_usize).inner == 0_u32, 'result[7] = 0');
+
+    // broadcast operation 
+
+    let mut sizes = ArrayTrait::new();
+    sizes.append(1_usize);
+    sizes.append(2_usize);
+    sizes.append(1_usize);
+    let mut data = ArrayTrait::new();
+    data.append(i33 { inner: 0_u32, sign: false });
+    data.append(i33 { inner: 1_u32, sign: false });
+    let tensor_2 = TensorTrait::<i33>::new(@sizes, @data);
+
+    let result = tensor_1.sub(@tensor_2).data;
+
+    assert(*result.at(0_usize).inner == 0_u32, 'result[0] = 0');
+    assert(*result.at(1_usize).inner == 0_u32, 'result[1] = 0');
+    assert(*result.at(2_usize).inner == 2_u32, 'result[2] = 2');
+    assert(*result.at(3_usize).inner == 2_u32, 'result[3] = 2');
+    assert(*result.at(4_usize).inner == 4_u32, 'result[4] = 4');
+    assert(*result.at(5_usize).inner == 4_u32, 'result[5] = 4');
+    assert(*result.at(6_usize).inner == 6_u32, 'result[6] = 6');
+    assert(*result.at(7_usize).inner == 6_u32, 'result[7] = 6');
+}
+
+#[test]
+#[available_gas(20000000)]
+fn i33_mul_tensor() {
+    let tensor_1 = i33_tensor_helper();
+    let tensor_2 = i33_tensor_helper();
+
+    let result = tensor_1.mul(@tensor_2).data;
+
+    assert(*result.at(0_usize).inner == 0_u32, 'result[0] = 0');
+    assert(*result.at(1_usize).inner == 1_u32, 'result[1] = 1');
+    assert(*result.at(2_usize).inner == 4_u32, 'result[2] = 4');
+    assert(*result.at(3_usize).inner == 9_u32, 'result[3] = 9');
+    assert(*result.at(4_usize).inner == 16_u32, 'result[4] = 16');
+    assert(*result.at(5_usize).inner == 25_u32, 'result[5] = 25');
+    assert(*result.at(6_usize).inner == 36_u32, 'result[6] = 36');
+    assert(*result.at(7_usize).inner == 49_u32, 'result[7] = 49');
+
+    // broadcast operation 
+
+    let mut sizes = ArrayTrait::new();
+    sizes.append(1_usize);
+    sizes.append(2_usize);
+    sizes.append(1_usize);
+    let mut data = ArrayTrait::new();
+    data.append(i33 { inner: 10_u32, sign: false });
+    data.append(i33 { inner: 100_u32, sign: false });
+    let tensor_2 = TensorTrait::<i33>::new(@sizes, @data);
+
+    let result = tensor_1.mul(@tensor_2).data;
+
+    assert(*result.at(0_usize).inner == 0_u32, 'result[0] = 0');
+    assert(*result.at(1_usize).inner == 100_u32, 'result[1] = 100');
+    assert(*result.at(2_usize).inner == 20_u32, 'result[2] = 20');
+    assert(*result.at(3_usize).inner == 300_u32, 'result[3] = 300');
+    assert(*result.at(4_usize).inner == 40_u32, 'result[4] = 40');
+    assert(*result.at(5_usize).inner == 500_u32, 'result[5] = 500');
+    assert(*result.at(6_usize).inner == 60_u32, 'result[6] = 60');
+    assert(*result.at(7_usize).inner == 700_u32, 'result[7] = 700');
+}
+
+#[test]
+#[available_gas(20000000)]
+fn i33_div_tensor() {
+    let mut sizes = ArrayTrait::new();
+    sizes.append(2_usize);
+    sizes.append(2_usize);
+    sizes.append(2_usize);
+    let mut data = ArrayTrait::new();
+    data.append(i33 { inner: 100_u32, sign: false });
+    data.append(i33 { inner: 200_u32, sign: false });
+    data.append(i33 { inner: 300_u32, sign: false });
+    data.append(i33 { inner: 400_u32, sign: false });
+    data.append(i33 { inner: 500_u32, sign: false });
+    data.append(i33 { inner: 600_u32, sign: false });
+    data.append(i33 { inner: 700_u32, sign: false });
+    data.append(i33 { inner: 800_u32, sign: false });
+    let tensor_1 = TensorTrait::<i33>::new(@sizes, @data);
+
+    let mut sizes = ArrayTrait::new();
+    sizes.append(2_usize);
+    sizes.append(2_usize);
+    sizes.append(2_usize);
+    let mut data = ArrayTrait::new();
+    data.append(i33 { inner: 100_u32, sign: false });
+    data.append(i33 { inner: 200_u32, sign: false });
+    data.append(i33 { inner: 300_u32, sign: false });
+    data.append(i33 { inner: 400_u32, sign: false });
+    data.append(i33 { inner: 500_u32, sign: false });
+    data.append(i33 { inner: 600_u32, sign: false });
+    data.append(i33 { inner: 700_u32, sign: false });
+    data.append(i33 { inner: 800_u32, sign: false });
+    let tensor_2 = TensorTrait::<i33>::new(@sizes, @data);
+
+    let result = tensor_1.div(@tensor_2).data;
+
+    assert(*result.at(0_usize).inner == 1_u32, 'result[0] = 1');
+    assert(*result.at(1_usize).inner == 1_u32, 'result[1] = 1');
+    assert(*result.at(2_usize).inner == 1_u32, 'result[2] = 1');
+    assert(*result.at(3_usize).inner == 1_u32, 'result[3] = 1');
+    assert(*result.at(4_usize).inner == 1_u32, 'result[4] = 1');
+    assert(*result.at(5_usize).inner == 1_u32, 'result[5] = 1');
+    assert(*result.at(6_usize).inner == 1_u32, 'result[6] = 1');
+    assert(*result.at(7_usize).inner == 1_u32, 'result[7] = 1');
+
+    // broadcast operation 
+
+    let mut sizes = ArrayTrait::new();
+    sizes.append(1_usize);
+    sizes.append(2_usize);
+    sizes.append(1_usize);
+    let mut data = ArrayTrait::new();
+    data.append(i33 { inner: 10_u32, sign: false });
+    data.append(i33 { inner: 100_u32, sign: false });
+    let tensor_2 = TensorTrait::<i33>::new(@sizes, @data);
+
+    let result = tensor_1.div(@tensor_2).data;
+
+    assert(*result.at(0_usize).inner == 10_u32, 'result[0] = 10');
+    assert(*result.at(1_usize).inner == 2_u32, 'result[1] = 2');
+    assert(*result.at(2_usize).inner == 30_u32, 'result[2] = 30');
+    assert(*result.at(3_usize).inner == 4_u32, 'result[3] = 4');
+    assert(*result.at(4_usize).inner == 50_u32, 'result[4] = 50');
+    assert(*result.at(5_usize).inner == 6_u32, 'result[5] = 6');
+    assert(*result.at(6_usize).inner == 70_u32, 'result[6] = 70');
+    assert(*result.at(7_usize).inner == 8_u32, 'result[7] = 8');
+}
+
+fn i33_tensor_helper() -> Tensor<i33> {
+    let mut sizes = ArrayTrait::new();
+    sizes.append(2_usize);
+    sizes.append(2_usize);
+    sizes.append(2_usize);
+
+    let mut data = ArrayTrait::new();
+    data.append(i33 { inner: 0_u32, sign: false });
+    data.append(i33 { inner: 1_u32, sign: false });
+    data.append(i33 { inner: 2_u32, sign: false });
+    data.append(i33 { inner: 3_u32, sign: false });
+    data.append(i33 { inner: 4_u32, sign: false });
+    data.append(i33 { inner: 5_u32, sign: false });
+    data.append(i33 { inner: 6_u32, sign: false });
+    data.append(i33 { inner: 7_u32, sign: false });
+
+    let tensor = TensorTrait::<i33>::new(@sizes, @data);
+
+    return tensor;
+}

--- a/src/utils.cairo
+++ b/src/utils.cairo
@@ -1,0 +1,16 @@
+use array::ArrayTrait;
+use option::OptionTrait;
+
+// Fake macro to compute gas left
+// TODO: Remove when automatically handled by compiler.
+#[inline(always)]
+fn check_gas() {
+    match gas::withdraw_gas_all(get_builtin_costs()) {
+        Option::Some(_) => {},
+        Option::None(_) => {
+            let mut data = ArrayTrait::new();
+            data.append('Out of gas');
+            panic(data);
+        }
+    }
+}


### PR DESCRIPTION
### feat: Tensor implementation in Cairo 1.0

## Pull Request type

Please check the type of change your PR introduces:

- [ ] Bugfix
- [X] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

There is no full implementation of Tensor. 
The idea is to remove Vector and Matrix in the future and use only the Tensor object as an nd-array. 
This PR is for simple implementation of a Tensor of type i33 with broadcast element-wise operations. 

More tensors operations (e.g; reduce_sum, dot product...), will be part of a next PR

## What is the new behavior?

- implement max Tensor
- broadcast element-wise operations
- unit tests

## Does this introduce a breaking change?

- [ ] Yes
- [X] No

<!-- If this does introduce a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

<!-- Any other information that is important to this PR, such as screenshots of how the component looks before and after the change. -->
