### PR TITLE
Optimize tensor - replace @Array with Span and use span.pop_front() for iteration

### DIFF
--- a/src/operators/math/tensor/core.cairo
+++ b/src/operators/math/tensor/core.cairo
@@ -97,19 +97,19 @@ fn ravel_index(mut shape: Span<usize>, mut indices: Span<usize>) -> usize {
     raveled_index
 }
 
-// /// Converts a one-dimensional index to a multi-dimensional index for a tensor with the given shape.
-// ///
-// /// # Arguments
-// /// * `index` - A usize representing the one-dimensional index.
-// /// * `shape` - A span containing the shape of the tensor as usize elements.
-// ///
-// /// # Panics
-// /// * Panics if the index is out of bounds for the given shape.
-// /// * Panics if shape is empty.
-// /// * Panics if gas limit is exceeded during execution.
-// ///
-// /// # Returns
-// /// * A Span of usize representing the multi-dimensional index.
+/// Converts a one-dimensional index to a multi-dimensional index for a tensor with the given shape.
+///
+/// # Arguments
+/// * `index` - A usize representing the one-dimensional index.
+/// * `shape` - A span containing the shape of the tensor as usize elements.
+///
+/// # Panics
+/// * Panics if the index is out of bounds for the given shape.
+/// * Panics if shape is empty.
+/// * Panics if gas limit is exceeded during execution.
+///
+/// # Returns
+/// * A Span of usize representing the multi-dimensional index.
 fn unravel_index(index: usize, mut shape: Span<usize>) -> Span<usize> {
     assert(shape.len() > 0, 'shape cannot be empty');
 

--- a/src/operators/math/tensor/core.cairo
+++ b/src/operators/math/tensor/core.cairo
@@ -10,10 +10,10 @@ use onnx_cairo::operators::math::tensor::helpers::check_shape;
 ///
 /// # Struct fields
 /// * `shape` - A span containing the shape of the tensor as usize elements.
-/// * `data` - A reference Array of data elements of generic type T.
+/// * `data` - A span containing the data elements of generic type T.
 struct Tensor<T> {
     shape: Span<usize>,
-    data: @Array<T>
+    data: Span<T>
 }
 
 impl TensorCopy<T> of Copy<Tensor<T>>;
@@ -34,7 +34,7 @@ impl TensorDrop<T> of Drop<Tensor<T>>;
 /// * `reduce_sum` - Reduces the tensor by summing along the specified axis.
 /// * `argmax` - Returns the index of the maximum value along the specified axis.
 trait TensorTrait<T> {
-    fn new(shape: Span<usize>, data: @Array<T>) -> Tensor<T>;
+    fn new(shape: Span<usize>, data: Span<T>) -> Tensor<T>;
     fn at(self: @Tensor<T>, indices: Span<usize>) -> T;
     fn min(self: @Tensor<T>) -> T;
     fn max(self: @Tensor<T>) -> T;
@@ -42,7 +42,7 @@ trait TensorTrait<T> {
     fn ravel_index(self: @Tensor<T>, indices: Span<usize>) -> usize;
     fn unravel_index(self: @Tensor<T>, index: usize) -> Span<usize>;
     fn reshape(self: @Tensor<T>, target_shape: Span<usize>) -> Tensor<T>;
-    fn transpose(self: @Tensor<T>, axes: @Array<usize>) -> Tensor<T>;
+    fn transpose(self: @Tensor<T>, axes: Span<usize>) -> Tensor<T>;
     fn reduce_sum(self: @Tensor<T>, axis: usize) -> Tensor<T>;
     fn argmax(self: @Tensor<T>, axis: usize) -> Tensor<usize>;
 }
@@ -51,14 +51,14 @@ trait TensorTrait<T> {
 ///
 /// # Arguments
 /// * `shape` - A span containing the shape of the tensor as usize elements.
-/// * `data` - A reference-counted Array of data elements of type T.
+/// * `data` -  A span containing the data elements of type T.
 ///
 /// # Panics
 /// * Panics if the shape and data length are incompatible.
 ///
 /// # Returns
 /// * A new Tensor with the specified shape and data.
-fn new_tensor<T>(shape: Span<usize>, data: @Array<T>) -> Tensor<T> {
+fn new_tensor<T>(shape: Span<usize>, data: Span<T>) -> Tensor<T> {
     check_shape::<T>(shape, data);
     Tensor::<T> { shape, data }
 }

--- a/src/operators/math/tensor/helpers.cairo
+++ b/src/operators/math/tensor/helpers.cairo
@@ -37,11 +37,11 @@ fn len_from_shape(shape: Span<usize>) -> usize {
 ///
 /// # Arguments
 /// * `shape` - A span containing the shape of the tensor as usize elements.
-/// * `data` - A reference-counted Array of data elements of generic type T.
+/// * `data` -  A span containing the data elements of generic type T.
 ///
 /// # Panics
 /// * Panics if the shape and data array are incompatible.
-fn check_shape<T>(shape: Span<usize>, data: @Array<T>) {
+fn check_shape<T>(shape: Span<usize>, data: Span<T>) {
     assert(len_from_shape(shape) == data.len(), 'wrong tensor shape');
 }
 
@@ -147,7 +147,7 @@ fn reduce_output_shape(input_shape: Span<usize>, axis: usize) -> Span<usize> {
 ///
 /// # Arguments
 /// * `input_shape` - A span containing the input tensor's shape as usize elements.
-/// * `axes` - A reference-counted Array of usize elements representing the axes permutation.
+/// * `axes` -  A span containing the usize elements representing the axes permutation.
 ///
 /// # Panics
 /// * Panics if shape and axes length are not equal.
@@ -156,7 +156,7 @@ fn reduce_output_shape(input_shape: Span<usize>, axis: usize) -> Span<usize> {
 ///
 /// # Returns
 /// * A Span of usize representing the output shape after permutation.
-fn permutation_output_shape(input_shape: Span<usize>, axes: @Array<usize>) -> Span<usize> {
+fn permutation_output_shape(input_shape: Span<usize>, axes: Span<usize>) -> Span<usize> {
     assert(input_shape.len() == axes.len(), 'input_shape/indices len unequal');
 
     let mut output_shape = ArrayTrait::new();
@@ -220,7 +220,7 @@ fn combine_indices(output_indices: Span<usize>, axis_index: usize, axis: usize) 
 /// Helper function that finds the index of a target axis in the given axes array.
 ///
 /// # Arguments
-/// * `axes` - A reference-counted Array of usize elements representing the axes.
+/// * `axes` -  A span containing the usize elements representing the axes.
 /// * `target_axis` - A usize representing the target axis.
 ///
 /// # Panics
@@ -229,7 +229,7 @@ fn combine_indices(output_indices: Span<usize>, axis_index: usize, axis: usize) 
 ///
 /// # Returns
 /// * A usize representing the index of the target axis in the given axes array.
-fn find_axis(axes: @Array<usize>, target_axis: usize) -> usize {
+fn find_axis(axes: Span <usize>, target_axis: usize) -> usize {
     assert(target_axis < axes.len(), 'target_axis is out of range');
 
     let mut axis: usize = 0;

--- a/src/operators/math/tensor/helpers.cairo
+++ b/src/operators/math/tensor/helpers.cairo
@@ -15,19 +15,17 @@ use onnx_cairo::operators::math::tensor::core::stride;
 ///
 /// # Returns
 /// * A usize representing the number of elements in the tensor.
-fn len_from_shape(shape: Span<usize>) -> usize {
+fn len_from_shape(mut shape: Span<usize>) -> usize {
     let mut result: usize = 1;
 
-    let mut i: usize = 0;
     loop {
         check_gas();
 
-        if i == shape.len() {
+        if shape.len() == 0 {
             break ();
         }
 
-        result *= *shape.at(i);
-        i += 1;
+        result *= *shape.pop_front().unwrap();
     };
 
     return result;
@@ -53,24 +51,23 @@ fn check_shape<T>(shape: Span<usize>, data: Span<T>) {
 ///
 /// # Panics
 /// * Panics if the shapes are not compatible for broadcasting.
-fn check_compatibility(shape_1: Span<usize>, shape_2: Span<usize>) {
+fn check_compatibility(mut shape_1: Span<usize>, mut shape_2: Span<usize>) {
     assert(shape_1.len() == shape_2.len(), 'tensors shape must match');
 
-    let mut n: usize = 0;
     loop {
         check_gas();
 
+        if shape_1.len() == 0 {
+            break ();
+        }
+
+        let shape_1_val = *shape_1.pop_front().unwrap();
+        let shape_2_val = *shape_2.pop_front().unwrap();
+
         assert(
-            *shape_1.at(
-                n
-            ) == *shape_2.at(n) | *shape_1.at(n) == 1_usize | *shape_2.at(n) == 1_usize,
+            shape_1_val == shape_2_val | shape_1_val == 1 | shape_2_val == 1,
             'tensors shape must match'
         );
-
-        n += 1;
-        if n == shape_1.len() {
-            break ();
-        };
     };
 }
 
@@ -86,20 +83,22 @@ fn check_compatibility(shape_1: Span<usize>, shape_2: Span<usize>) {
 ///
 /// # Returns
 /// * A usize representing the index in the broadcasted tensor.
-fn broadcast_index_mapping(shape: Span<usize>, indices: Span<usize>) -> usize {
+fn broadcast_index_mapping(mut shape: Span<usize>, mut indices: Span<usize>) -> usize {
     assert(shape.len() == indices.len(), 'shape/indices len must be equal');
     let mut result = 0_usize;
+    let mut stride = stride(shape);
 
-    let mut n: usize = 0;
     loop {
         check_gas();
 
-        let stride = stride(shape);
-        let index = (*indices.at(n) % *shape.at(n)) * *stride.at(n);
+        let indices_val = *indices.pop_front().unwrap();
+        let shape_val = *shape.pop_front().unwrap();
+        let stride_val = *stride.pop_front().unwrap();
+
+        let index = (indices_val % shape_val) * stride_val;
         result += index;
 
-        n += 1;
-        if n == shape.len() {
+        if shape.len() == 0 {
             break ();
         };
     };
@@ -120,22 +119,23 @@ fn broadcast_index_mapping(shape: Span<usize>, indices: Span<usize>) -> usize {
 ///
 /// # Returns
 /// * A Span of usize representing the output shape after reduction.
-fn reduce_output_shape(input_shape: Span<usize>, axis: usize) -> Span<usize> {
-    assert(input_shape.len() > 0, 'input_shape cannot be empty');
-    assert(axis <= input_shape.len(), 'axis is out of bound');
+fn reduce_output_shape(mut input_shape: Span<usize>, axis: usize) -> Span<usize> {
+    let input_shape_len = input_shape.len();
+
+    assert(input_shape_len > 0, 'input_shape cannot be empty');
+    assert(axis <= input_shape_len, 'axis is out of bound');
 
     let mut reduced = ArrayTrait::new();
-
-    let mut n: usize = 0;
+    let mut current_axis: usize = 0;
     loop {
         check_gas();
 
-        if n != axis {
-            reduced.append(*input_shape.at(n));
+        if current_axis != axis {
+            reduced.append(*input_shape.pop_front().unwrap());
         }
 
-        n += 1;
-        if n == input_shape.len() {
+        current_axis += 1;
+        if current_axis == input_shape_len {
             break ();
         };
     };
@@ -156,19 +156,19 @@ fn reduce_output_shape(input_shape: Span<usize>, axis: usize) -> Span<usize> {
 ///
 /// # Returns
 /// * A Span of usize representing the output shape after permutation.
-fn permutation_output_shape(input_shape: Span<usize>, axes: Span<usize>) -> Span<usize> {
-    assert(input_shape.len() == axes.len(), 'input_shape/indices len unequal');
+fn permutation_output_shape(input_shape: Span<usize>, mut axes: Span<usize>) -> Span<usize> {
+    let axes_len = axes.len();
+    assert(input_shape.len() == axes_len, 'input_shape/indices len unequal');
 
     let mut output_shape = ArrayTrait::new();
     let mut axis: usize = 0;
-
     loop {
         check_gas();
-        if axis == axes.len() {
+        if axis == axes_len {
             break ();
         }
 
-        output_shape.append(*input_shape.at(*axes.at(axis)));
+        output_shape.append(*input_shape.at(*axes.pop_front().unwrap()));
         axis += 1;
     };
 
@@ -216,11 +216,10 @@ fn combine_indices(output_indices: Span<usize>, axis_index: usize, axis: usize) 
     return result.span();
 }
 
-
 /// Helper function that finds the index of a target axis in the given axes array.
 ///
 /// # Arguments
-/// * `axes` -  A span containing the usize elements representing the axes.
+/// * `axes` - A span containing the usize elements representing the axes.
 /// * `target_axis` - A usize representing the target axis.
 ///
 /// # Panics
@@ -229,17 +228,19 @@ fn combine_indices(output_indices: Span<usize>, axis_index: usize, axis: usize) 
 ///
 /// # Returns
 /// * A usize representing the index of the target axis in the given axes array.
-fn find_axis(axes: Span <usize>, target_axis: usize) -> usize {
+fn find_axis(mut axes: Span<usize>, target_axis: usize) -> usize {
     assert(target_axis < axes.len(), 'target_axis is out of range');
 
     let mut axis: usize = 0;
     loop {
         check_gas();
-        if axis == axes.len() {
+
+        if axes.len() == 0 {
             break ();
         }
 
-        if *axes.at(axis) == target_axis {
+        let current_axis = *axes.pop_front().unwrap();
+        if current_axis == target_axis {
             break ();
         }
         axis += 1;

--- a/src/operators/math/tensor/tensor_i32.cairo
+++ b/src/operators/math/tensor/tensor_i32.cairo
@@ -281,20 +281,20 @@ fn i32_at_tensor(self: @Tensor<i32>, indices: Span<usize>) -> i32 {
 ///
 /// # Returns
 /// * An i32 value representing the minimum value in the array.
-fn i32_min_tensor(vec: Span::<i32>) -> i32 {
+fn i32_min_tensor(mut vec: Span::<i32>) -> i32 {
     let mut min_value: i32 = IntegerTrait::new(2147483647_u32, false);
 
-    let mut i: usize = 0;
     loop {
         check_gas();
 
-        let check_min = min_value.min(*vec.at(i));
+        let current_value = *vec.pop_front().unwrap();
+
+        let check_min = min_value.min(current_value);
         if (min_value > check_min) {
             min_value = check_min;
         }
 
-        i += 1;
-        if i == vec.len() {
+        if vec.len() == 0 {
             break ();
         };
     };
@@ -312,27 +312,26 @@ fn i32_min_tensor(vec: Span::<i32>) -> i32 {
 ///
 /// # Returns
 /// * An i32 value representing the maximum value in the array.
-fn i32_max_tensor(vec: Span::<i32>) -> i32 {
+fn i32_max_tensor(mut vec: Span::<i32>) -> i32 {
     let mut max_value: i32 = IntegerTrait::new(0_u32, false);
 
-    let mut i: usize = 0;
     loop {
         check_gas();
 
-        let check_max = max_value.max(*vec.at(i));
+        let current_value = *vec.pop_front().unwrap();
+
+        let check_max = max_value.max(current_value);
         if (max_value < check_max) {
             max_value = check_max;
         }
 
-        i += 1;
-        if i == vec.len() {
+        if vec.len() == 0 {
             break ();
         };
     };
 
     return max_value;
 }
-
 
 // --- BROADCAST OPERATIONS ---
 

--- a/src/operators/math/tensor/tensor_i32.cairo
+++ b/src/operators/math/tensor/tensor_i32.cairo
@@ -29,14 +29,14 @@ impl i32Tensor of TensorTrait<i32> {
     ///
     /// # Arguments
     /// * `shape` - A span representing the shape of the tensor.
-    /// * `data` - A reference-counted array of i32 elements.
+    /// * `data` -  A span containing the array of i32 elements.
     ///
     /// # Panics
     /// * Panics if the shape and data length are incompatible.
     ///
     /// # Returns
     /// * A new `Tensor<i32>` instance.
-    fn new(shape: Span<usize>, data: @Array<i32>) -> Tensor<i32> {
+    fn new(shape: Span<usize>, data: Span<i32>) -> Tensor<i32> {
         new_tensor(shape, data)
     }
 
@@ -181,7 +181,7 @@ impl i32Tensor of TensorTrait<i32> {
     ///
     /// # Arguments
     /// * `self` - The input tensor.
-    /// * `axes` - A reference-counted array representing the order in which the axes should be transposed.
+    /// * `axes` -  A span containing the array representing the order in which the axes should be transposed.
     ///
     /// # Panics
     /// * Panics if the length of the axes array is not equal to the rank of the input tensor.
@@ -189,7 +189,7 @@ impl i32Tensor of TensorTrait<i32> {
     ///
     /// # Returns
     /// * A new `Tensor<i32>` instance with the axes transposed according to the specified order.
-    fn transpose(self: @Tensor<i32>, axes: @Array<usize>) -> Tensor<i32> {
+    fn transpose(self: @Tensor<i32>, axes: Span<usize>) -> Tensor<i32> {
         i32_transpose(self, axes)
     }
 }
@@ -274,14 +274,14 @@ fn i32_at_tensor(self: @Tensor<i32>, indices: Span<usize>) -> i32 {
 /// Finds the minimum value in a `Tensor<i32>` array.
 ///
 /// # Arguments
-/// * `vec` - A reference-counted Array of i32 elements.
+/// * `vec` -  A span containing the data array of i32 elements.
 ///
 /// # Panics
 /// * Panics if gas limit is exceeded during execution.
 ///
 /// # Returns
 /// * An i32 value representing the minimum value in the array.
-fn i32_min_tensor(vec: @Array::<i32>) -> i32 {
+fn i32_min_tensor(vec: Span::<i32>) -> i32 {
     let mut min_value: i32 = IntegerTrait::new(2147483647_u32, false);
 
     let mut i: usize = 0;
@@ -305,14 +305,14 @@ fn i32_min_tensor(vec: @Array::<i32>) -> i32 {
 /// Finds the maximum value in a `Tensor<i32>` array.
 ///
 /// # Arguments
-/// * `vec` - A reference-counted Array of i32 elements.
+/// * `vec` -  A span containing the data array of i32 elements.
 ///
 /// # Panics
 /// * Panics if gas limit is exceeded during execution.
 ///
 /// # Returns
 /// * An i32 value representing the maximum value in the array.
-fn i32_max_tensor(vec: @Array::<i32>) -> i32 {
+fn i32_max_tensor(vec: Span::<i32>) -> i32 {
     let mut max_value: i32 = IntegerTrait::new(0_u32, false);
 
     let mut i: usize = 0;
@@ -370,7 +370,7 @@ fn i32_add_tensor(self: @Tensor<i32>, other: @Tensor<i32>) -> Tensor<i32> {
         };
     };
 
-    return TensorTrait::<i32>::new(*self.shape, @result);
+    return TensorTrait::<i32>::new(*self.shape, result.span());
 }
 
 /// Subtracts two `Tensor<i32>` instances element-wise with broadcasting.
@@ -407,7 +407,7 @@ fn i32_sub_tensor(self: @Tensor<i32>, other: @Tensor<i32>) -> Tensor<i32> {
         };
     };
 
-    return TensorTrait::<i32>::new(*self.shape, @result);
+    return TensorTrait::<i32>::new(*self.shape, result.span());
 }
 
 /// Multiplies two `Tensor<i32>` instances element-wise with broadcasting.
@@ -444,7 +444,7 @@ fn i32_mul_tensor(self: @Tensor<i32>, other: @Tensor<i32>) -> Tensor<i32> {
         };
     };
 
-    return TensorTrait::<i32>::new(*self.shape, @result);
+    return TensorTrait::<i32>::new(*self.shape, result.span());
 }
 
 /// Divides two `Tensor<i32>` instances element-wise with broadcasting.
@@ -481,7 +481,7 @@ fn i32_div_tensor(self: @Tensor<i32>, other: @Tensor<i32>) -> Tensor<i32> {
         };
     };
 
-    return TensorTrait::<i32>::new(*self.shape, @result);
+    return TensorTrait::<i32>::new(*self.shape, result.span());
 }
 
 /// --- REDUCE OPERATIONS ---
@@ -520,7 +520,7 @@ fn i32_reduce_sum(self: @Tensor<i32>, axis: usize) -> Tensor<i32> {
         };
     };
 
-    return TensorTrait::<i32>::new(output_shape, @output_data);
+    return TensorTrait::<i32>::new(output_shape, output_data.span());
 }
 
 /// Helper function that accumulates the sum of elements along a specific axis.
@@ -595,7 +595,7 @@ fn i32_argmax(self: @Tensor<i32>, axis: usize) -> Tensor<usize> {
         };
     };
 
-    return TensorTrait::<usize>::new(output_shape, @output_data);
+    return TensorTrait::<usize>::new(output_shape, output_data.span());
 }
 
 /// Recursive helper function that finds the index of the maximum value along a specific axis.
@@ -646,7 +646,7 @@ fn find_argmax(
 ///
 /// # Arguments
 /// * `self` - The input tensor.
-/// * `axes` - A reference-counted Array of usize elements representing the axes permutation.
+/// * `axes` -  A span containing the usize elements representing the axes permutation.
 ///
 /// # Panics
 /// * Panics if the length of the axes array is not equal to the rank of the input tensor.
@@ -654,7 +654,7 @@ fn find_argmax(
 ///
 /// # Returns
 /// * A `Tensor<i32>` instance with the axes reordered according to the given permutation.
-fn i32_transpose(self: @Tensor<i32>, axes: @Array<usize>) -> Tensor<i32> {
+fn i32_transpose(self: @Tensor<i32>, axes: Span<usize>) -> Tensor<i32> {
     assert(axes.len() == (*self.shape).len(), 'shape and axes length unequal');
 
     let output_shape = permutation_output_shape(*self.shape, axes);
@@ -691,5 +691,5 @@ fn i32_transpose(self: @Tensor<i32>, axes: @Array<usize>) -> Tensor<i32> {
         output_index += 1;
     };
 
-    return TensorTrait::<i32>::new(output_shape, @output_data);
+    return TensorTrait::<i32>::new(output_shape, output_data.span());
 }

--- a/src/operators/math/tensor/tensor_u32.cairo
+++ b/src/operators/math/tensor/tensor_u32.cairo
@@ -26,14 +26,14 @@ impl U32Tensor of TensorTrait<u32> {
     ///
     /// # Arguments
     /// * `shape` - A span representing the shape of the tensor.
-    /// * `data` - A reference-counted array of u32 elements.
+    /// * `data` -  A span containing the data array of u32 elements.
     ///
     /// # Panics
     /// * Panics if the shape and data length are incompatible.
     ///
     /// # Returns
     /// * A new `Tensor<u32>` instance.
-    fn new(shape: Span<usize>, data: @Array<u32>) -> Tensor<u32> {
+    fn new(shape: Span<usize>, data: Span<u32>) -> Tensor<u32> {
         new_tensor(shape, data)
     }
 
@@ -178,7 +178,7 @@ impl U32Tensor of TensorTrait<u32> {
     ///
     /// # Arguments
     /// * `self` - The input tensor.
-    /// * `axes` - A reference-counted array representing the order in which the axes should be transposed.
+    /// * `axes` -  A span containing the array representing the order in which the axes should be transposed.
     ///
     /// # Panics
     /// * Panics if the length of the axes array is not equal to the rank of the input tensor.
@@ -186,7 +186,7 @@ impl U32Tensor of TensorTrait<u32> {
     ///
     /// # Returns
     /// * A new `Tensor<u32>` instance with the axes transposed according to the specified order.
-    fn transpose(self: @Tensor<u32>, axes: @Array<usize>) -> Tensor<u32> {
+    fn transpose(self: @Tensor<u32>, axes: Span<usize>) -> Tensor<u32> {
         u32_transpose(self, axes)
     }
 }
@@ -271,14 +271,14 @@ fn u32_at_tensor(self: @Tensor<u32>, indices: Span<usize>) -> u32 {
 /// Finds the minimum value in a `Tensor<u32>` array.
 ///
 /// # Arguments
-/// * `vec` - A reference-counted Array of u32 elements.
+/// * `vec` -  A span containing the data array of u32 elements.
 ///
 /// # Panics
 /// * Panics if gas limit is exceeded during execution.
 ///
 /// # Returns
 /// * An u32 value representing the minimum value in the array.
-fn u32_min_tensor(vec: @Array::<u32>) -> u32 {
+fn u32_min_tensor(vec: Span::<u32>) -> u32 {
     let mut min_value = 4294967295_u32;
 
     let mut i: usize = 0;
@@ -301,14 +301,14 @@ fn u32_min_tensor(vec: @Array::<u32>) -> u32 {
 /// Finds the maximum value in a `Tensor<u32>` array.
 ///
 /// # Arguments
-/// * `vec` - A reference-counted Array of u32 elements.
+/// * `vec` -  A span containing the data array u32 elements.
 ///
 /// # Panics
 /// * Panics if gas limit is exceeded during execution.
 ///
 /// # Returns
 /// * An u32 value representing the maximum value in the array.
-fn u32_max_tensor(vec: @Array::<u32>) -> u32 {
+fn u32_max_tensor(vec: Span::<u32>) -> u32 {
     let mut max_value = 0_u32;
     let mut i: usize = 0;
     loop {
@@ -363,7 +363,7 @@ fn u32_add_tensor(self: @Tensor<u32>, other: @Tensor<u32>) -> Tensor<u32> {
         };
     };
 
-    return TensorTrait::<u32>::new(*self.shape, @result);
+    return TensorTrait::<u32>::new(*self.shape, result.span());
 }
 
 /// Subtracts two `Tensor<u32>` instances element-wise with broadcasting.
@@ -400,7 +400,7 @@ fn u32_sub_tensor(self: @Tensor<u32>, other: @Tensor<u32>) -> Tensor<u32> {
         };
     };
 
-    return TensorTrait::<u32>::new(*self.shape, @result);
+    return TensorTrait::<u32>::new(*self.shape, result.span());
 }
 
 /// Multiplies two `Tensor<u32>` instances element-wise with broadcasting.
@@ -437,7 +437,7 @@ fn u32_mul_tensor(self: @Tensor<u32>, other: @Tensor<u32>) -> Tensor<u32> {
         };
     };
 
-    return TensorTrait::<u32>::new(*self.shape, @result);
+    return TensorTrait::<u32>::new(*self.shape, result.span());
 }
 
 /// Divides two `Tensor<u32>` instances element-wise with broadcasting.
@@ -474,7 +474,7 @@ fn u32_div_tensor(self: @Tensor<u32>, other: @Tensor<u32>) -> Tensor<u32> {
         };
     };
 
-    return TensorTrait::<u32>::new(*self.shape, @result);
+    return TensorTrait::<u32>::new(*self.shape, result.span());
 }
 
 /// --- REDUCE OPERATIONS ---
@@ -513,7 +513,7 @@ fn u32_reduce_sum(self: @Tensor<u32>, axis: usize) -> Tensor<u32> {
         };
     };
 
-    return TensorTrait::<u32>::new(output_shape, @output_data);
+    return TensorTrait::<u32>::new(output_shape, output_data.span());
 }
 
 /// Helper function that accumulates the sum of elements along a specific axis.
@@ -586,7 +586,7 @@ fn u32_argmax(self: @Tensor<u32>, axis: usize) -> Tensor<usize> {
         };
     };
 
-    return TensorTrait::<usize>::new(output_shape, @output_data);
+    return TensorTrait::<usize>::new(output_shape, output_data.span());
 }
 
 /// Recursive helper function that finds the index of the maximum value along a specific axis.
@@ -637,7 +637,7 @@ fn find_argmax(
 ///
 /// # Arguments
 /// * `self` - The input tensor.
-/// * `axes` - A reference-counted Array of usize elements representing the axes permutation.
+/// * `axes` -  A span containing the data representing the axes permutation.
 ///
 /// # Panics
 /// * Panics if the length of the axes array is not equal to the rank of the input tensor.
@@ -645,7 +645,7 @@ fn find_argmax(
 ///
 /// # Returns
 /// * A `Tensor<u32>` instance with the axes reordered according to the given permutation.
-fn u32_transpose(self: @Tensor<u32>, axes: @Array<usize>) -> Tensor<u32> {
+fn u32_transpose(self: @Tensor<u32>, axes: Span<usize>) -> Tensor<u32> {
     assert(axes.len() == (*self.shape).len(), 'shape and axes length unequal');
 
     let output_shape = permutation_output_shape(*self.shape, axes);
@@ -682,5 +682,5 @@ fn u32_transpose(self: @Tensor<u32>, axes: @Array<usize>) -> Tensor<u32> {
         output_index += 1;
     };
 
-    return TensorTrait::<u32>::new(output_shape, @output_data);
+    return TensorTrait::<u32>::new(output_shape, output_data.span());
 }

--- a/src/operators/math/tensor/tensor_u32.cairo
+++ b/src/operators/math/tensor/tensor_u32.cairo
@@ -278,19 +278,18 @@ fn u32_at_tensor(self: @Tensor<u32>, indices: Span<usize>) -> u32 {
 ///
 /// # Returns
 /// * An u32 value representing the minimum value in the array.
-fn u32_min_tensor(vec: Span::<u32>) -> u32 {
+fn u32_min_tensor(mut vec: Span::<u32>) -> u32 {
     let mut min_value = 4294967295_u32;
-
-    let mut i: usize = 0;
     loop {
         check_gas();
 
-        if (min_value > *vec.at(i)) {
-            min_value = *vec.at(i);
+        let current_value = *vec.pop_front().unwrap();
+
+        if (min_value > current_value) {
+            min_value = current_value;
         }
 
-        i += 1;
-        if i == vec.len() {
+        if vec.len() == 0 {
             break ();
         };
     };
@@ -308,18 +307,18 @@ fn u32_min_tensor(vec: Span::<u32>) -> u32 {
 ///
 /// # Returns
 /// * An u32 value representing the maximum value in the array.
-fn u32_max_tensor(vec: Span::<u32>) -> u32 {
+fn u32_max_tensor(mut vec: Span::<u32>) -> u32 {
     let mut max_value = 0_u32;
-    let mut i: usize = 0;
     loop {
         check_gas();
 
-        if (max_value < *vec.at(i)) {
-            max_value = *vec.at(i);
+        let current_value = *vec.pop_front().unwrap();
+
+        if (max_value < current_value) {
+            max_value = current_value;
         }
 
-        i += 1;
-        if i == vec.len() {
+        if vec.len() == 0 {
             break ();
         };
     };

--- a/src/tests/tensor_test.cairo
+++ b/src/tests/tensor_test.cairo
@@ -24,7 +24,7 @@ fn wrong_shape_tensor_test() {
     data.append(IntegerTrait::new(1_u32, false));
     data.append(IntegerTrait::new(2_u32, false));
 
-    let tensor = TensorTrait::<i32>::new(sizes.span(), @data);
+    let tensor = TensorTrait::<i32>::new(sizes.span(), data.span());
 }
 
 #[test]
@@ -184,7 +184,7 @@ fn add_tensor() {
     let mut data = ArrayTrait::new();
     data.append(IntegerTrait::new(10_u32, false));
     data.append(IntegerTrait::new(100_u32, false));
-    let tensor_2 = TensorTrait::<i32>::new(sizes.span(), @data);
+    let tensor_2 = TensorTrait::<i32>::new(sizes.span(), data.span());
 
     let result = (tensor_1 + tensor_2).data;
 
@@ -224,7 +224,7 @@ fn sub_tensor() {
     let mut data = ArrayTrait::new();
     data.append(IntegerTrait::new(0_u32, false));
     data.append(IntegerTrait::new(1_u32, false));
-    let tensor_2 = TensorTrait::<i32>::new(sizes.span(), @data);
+    let tensor_2 = TensorTrait::<i32>::new(sizes.span(), data.span());
 
     let result = (tensor_1 - tensor_2).data;
 
@@ -264,7 +264,7 @@ fn mul_tensor() {
     let mut data = ArrayTrait::new();
     data.append(IntegerTrait::new(10_u32, false));
     data.append(IntegerTrait::new(100_u32, false));
-    let tensor_2 = TensorTrait::<i32>::new(sizes.span(), @data);
+    let tensor_2 = TensorTrait::<i32>::new(sizes.span(), data.span());
 
     let result = (tensor_1 * tensor_2).data;
 
@@ -294,7 +294,7 @@ fn div_tensor() {
     data.append(IntegerTrait::new(600_u32, false));
     data.append(IntegerTrait::new(700_u32, false));
     data.append(IntegerTrait::new(800_u32, false));
-    let tensor_1 = TensorTrait::<i32>::new(sizes.span(), @data);
+    let tensor_1 = TensorTrait::<i32>::new(sizes.span(), data.span());
 
     let mut sizes = ArrayTrait::new();
     sizes.append(2);
@@ -309,7 +309,7 @@ fn div_tensor() {
     data.append(IntegerTrait::new(600_u32, false));
     data.append(IntegerTrait::new(700_u32, false));
     data.append(IntegerTrait::new(800_u32, false));
-    let tensor_2 = TensorTrait::<i32>::new(sizes.span(), @data);
+    let tensor_2 = TensorTrait::<i32>::new(sizes.span(), data.span());
 
     let result = (tensor_1 / tensor_2).data;
 
@@ -331,7 +331,7 @@ fn div_tensor() {
     let mut data = ArrayTrait::new();
     data.append(IntegerTrait::new(10_u32, false));
     data.append(IntegerTrait::new(100_u32, false));
-    let tensor_2 = TensorTrait::<i32>::new(sizes.span(), @data);
+    let tensor_2 = TensorTrait::<i32>::new(sizes.span(), data.span());
 
     let result = (tensor_1 / tensor_2).data;
 
@@ -424,7 +424,7 @@ fn tensor_transpose_2D() {
 
     let tensor = i32_tensor_2x2_helper();
 
-    let result = tensor.transpose(@axes);
+    let result = tensor.transpose(axes.span());
 
     assert(*result.data.at(0).mag == 0, 'result[0] = 0');
     assert(*result.data.at(1).mag == 2, 'result[1] = 2');
@@ -435,7 +435,7 @@ fn tensor_transpose_2D() {
 
     let tensor = i32_tensor_3x2_helper();
 
-    let result = tensor.transpose(@axes);
+    let result = tensor.transpose(axes.span());
 
     assert(*result.data.at(0).mag == 0, 'result[0] = 0');
     assert(*result.data.at(1).mag == 2, 'result[1] = 2');
@@ -448,7 +448,7 @@ fn tensor_transpose_2D() {
 
     let tensor = i32_tensor_2x3_helper();
 
-    let result = tensor.transpose(@axes);
+    let result = tensor.transpose(axes.span());
 
     assert(*result.data.at(0).mag == 0, 'result[0] = 0');
     assert(*result.data.at(1).mag == 3, 'result[1] = 3');
@@ -470,7 +470,7 @@ fn tensor_transpose_3D() {
     axes.append(2);
     axes.append(0);
 
-    let result = tensor.transpose(@axes).data;
+    let result = tensor.transpose(axes.span()).data;
 
     assert(*result.at(0).mag == 0, 'result[0] = 0');
     assert(*result.at(1).mag == 4, 'result[1] = 4');
@@ -486,7 +486,7 @@ fn tensor_transpose_3D() {
     axes.append(1);
     axes.append(0);
 
-    let result = tensor.transpose(@axes).data;
+    let result = tensor.transpose(axes.span()).data;
 
     assert(*result.at(0).mag == 0, 'result[0] = 0');
     assert(*result.at(1).mag == 4, 'result[1] = 4');
@@ -502,7 +502,7 @@ fn tensor_transpose_3D() {
     axes.append(2);
     axes.append(1);
 
-    let result = tensor.transpose(@axes).data;
+    let result = tensor.transpose(axes.span()).data;
 
     assert(*result.at(0).mag == 0, 'result[0] = 0');
     assert(*result.at(1).mag == 2, 'result[1] = 2');
@@ -520,7 +520,7 @@ fn tensor_transpose_3D() {
     axes.append(2);
     axes.append(0);
 
-    let result = tensor.transpose(@axes);
+    let result = tensor.transpose(axes.span());
 
     assert(*result.data.at(0).mag == 0, 'result[0] = 0');
     assert(*result.data.at(1).mag == 4, 'result[1] = 4');
@@ -543,7 +543,7 @@ fn tensor_transpose_3D() {
     axes.append(1);
     axes.append(0);
 
-    let result = tensor.transpose(@axes);
+    let result = tensor.transpose(axes.span());
 
     assert(*result.data.at(0).mag == 0, 'result[0] = 0');
     assert(*result.data.at(1).mag == 4, 'result[1] = 4');
@@ -566,7 +566,7 @@ fn tensor_transpose_3D() {
     axes.append(2);
     axes.append(1);
 
-    let result = tensor.transpose(@axes);
+    let result = tensor.transpose(axes.span());
 
     assert(*result.data.at(0).mag == 0, 'result[0] = 0');
     assert(*result.data.at(1).mag == 2, 'result[1] = 2');
@@ -598,7 +598,7 @@ fn i32_tensor_2x2_helper() -> Tensor<i32> {
     data.append(IntegerTrait::new(2_u32, false));
     data.append(IntegerTrait::new(3_u32, false));
 
-    let tensor = TensorTrait::<i32>::new(sizes.span(), @data);
+    let tensor = TensorTrait::<i32>::new(sizes.span(), data.span());
 
     return tensor;
 }
@@ -616,7 +616,7 @@ fn i32_tensor_3x2_helper() -> Tensor<i32> {
     data.append(IntegerTrait::new(4_u32, false));
     data.append(IntegerTrait::new(5_u32, false));
 
-    let tensor = TensorTrait::<i32>::new(sizes.span(), @data);
+    let tensor = TensorTrait::<i32>::new(sizes.span(), data.span());
 
     return tensor;
 }
@@ -634,7 +634,7 @@ fn i32_tensor_2x3_helper() -> Tensor<i32> {
     data.append(IntegerTrait::new(4_u32, false));
     data.append(IntegerTrait::new(5_u32, false));
 
-    let tensor = TensorTrait::<i32>::new(sizes.span(), @data);
+    let tensor = TensorTrait::<i32>::new(sizes.span(), data.span());
 
     return tensor;
 }
@@ -657,7 +657,7 @@ fn i32_tensor_2x2x2_helper() -> Tensor<i32> {
     data.append(IntegerTrait::new(6_u32, false));
     data.append(IntegerTrait::new(7_u32, false));
 
-    let tensor = TensorTrait::<i32>::new(sizes.span(), @data);
+    let tensor = TensorTrait::<i32>::new(sizes.span(), data.span());
 
     return tensor;
 }
@@ -682,7 +682,7 @@ fn i32_tensor_3x2x2_helper() -> Tensor<i32> {
     data.append(IntegerTrait::new(10_u32, false));
     data.append(IntegerTrait::new(11_u32, false));
 
-    let tensor = TensorTrait::<i32>::new(sizes.span(), @data);
+    let tensor = TensorTrait::<i32>::new(sizes.span(), data.span());
 
     return tensor;
 }


### PR DESCRIPTION
### Optimize tensor - replace @Array with Span and use span.pop_front() for iteration

## Pull Request type

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [X] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

- Currently, the data is defined as @Array when we should be using span. 
- We use span.at() in iterations when we should be using span.pop_front(). 

## What is the new behavior?

- Use Span instead of @Array
- Use span.pop_front() for iteration - a lot more efficient.
 
## Does this introduce a breaking change?

- [ ] Yes
- [X] No

<!-- If this does introduce a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

<!-- Any other information that is important to this PR, such as screenshots of how the component looks before and after the change. -->
