### PR TITLE
Feat: tensor.matmul

### DIFF
--- a/docs/COMPATIBILITY.md
+++ b/docs/COMPATIBILITY.md
@@ -4,19 +4,24 @@ To see the full list of available ONNX Operators refer to [this table](https://g
 
 You can see below the list of current supported ONNX Operators:
 
-| Operator | Implemented |
-| :--------: | :-----------: |
-| Dot | :white_check_mark: |
-| Add | :white_check_mark: |
-| Argmax | :white_check_mark: |
+| Operator  |    Implemented     |
+| :-------: | :----------------: |
+|    Dot    | :white_check_mark: |
+|    Add    | :white_check_mark: |
+|    Sub    | :white_check_mark: |
+|    Mul    | :white_check_mark: |
+|    Div    | :white_check_mark: |
+|  MatMul   | :white_check_mark: |
+| Transpose | :white_check_mark: |
+|  Argmax   | :white_check_mark: |
 | ReduceSum | :white_check_mark: |
-| ReLU | :white_check_mark: |
-| Softmax | :white_check_mark: |
+|   ReLU    | :white_check_mark: |
+|  Softmax  | :white_check_mark: |
 
 Performance optimizations:
 
-| Optimization | Implemented |
-| :--------: | :-----------: |
+|    Optimization    |    Implemented     |
+| :----------------: | :----------------: |
 | 8-bit quantization | :white_check_mark: |
 
 Current Operators support: **6/156 (4%)**

--- a/src/operators/math/tensor/core.cairo
+++ b/src/operators/math/tensor/core.cairo
@@ -33,6 +33,7 @@ impl TensorDrop<T> of Drop<Tensor<T>>;
 /// * `transpose` - Returns a new tensor with the axes rearranged according to the given array.
 /// * `reduce_sum` - Reduces the tensor by summing along the specified axis.
 /// * `argmax` - Returns the index of the maximum value along the specified axis.
+/// * `matmul` - Performs matrix multiplication.
 trait TensorTrait<T> {
     fn new(shape: Span<usize>, data: Span<T>) -> Tensor<T>;
     fn at(self: @Tensor<T>, indices: Span<usize>) -> T;

--- a/src/operators/math/tensor/core.cairo
+++ b/src/operators/math/tensor/core.cairo
@@ -45,6 +45,7 @@ trait TensorTrait<T> {
     fn transpose(self: @Tensor<T>, axes: Span<usize>) -> Tensor<T>;
     fn reduce_sum(self: @Tensor<T>, axis: usize) -> Tensor<T>;
     fn argmax(self: @Tensor<T>, axis: usize) -> Tensor<usize>;
+    fn matmul(self: @Tensor<T>, other: @Tensor<T>) -> Tensor<T>;
 }
 
 /// Constructs a new tensor with the given shape and data array after checking compatibility.

--- a/src/operators/math/tensor/core.cairo
+++ b/src/operators/math/tensor/core.cairo
@@ -33,7 +33,7 @@ impl TensorDrop<T> of Drop<Tensor<T>>;
 /// * `transpose` - Returns a new tensor with the axes rearranged according to the given array.
 /// * `reduce_sum` - Reduces the tensor by summing along the specified axis.
 /// * `argmax` - Returns the index of the maximum value along the specified axis.
-/// * `matmul` - Performs matrix multiplication.
+/// * `mul` - Performs matrix multiplication.
 trait TensorTrait<T> {
     fn new(shape: Span<usize>, data: Span<T>) -> Tensor<T>;
     fn at(self: @Tensor<T>, indices: Span<usize>) -> T;
@@ -46,7 +46,7 @@ trait TensorTrait<T> {
     fn transpose(self: @Tensor<T>, axes: Span<usize>) -> Tensor<T>;
     fn reduce_sum(self: @Tensor<T>, axis: usize) -> Tensor<T>;
     fn argmax(self: @Tensor<T>, axis: usize) -> Tensor<usize>;
-    fn matmul(self: @Tensor<T>, other: @Tensor<T>) -> Tensor<T>;
+    fn mul(self: @Tensor<T>, other: @Tensor<T>) -> Tensor<T>;
 }
 
 /// Constructs a new tensor with the given shape and data array after checking compatibility.

--- a/src/operators/math/tensor/core.cairo
+++ b/src/operators/math/tensor/core.cairo
@@ -33,7 +33,7 @@ impl TensorDrop<T> of Drop<Tensor<T>>;
 /// * `transpose` - Returns a new tensor with the axes rearranged according to the given array.
 /// * `reduce_sum` - Reduces the tensor by summing along the specified axis.
 /// * `argmax` - Returns the index of the maximum value along the specified axis.
-/// * `mul` - Performs matrix multiplication.
+/// * `matmul` - Performs matrix multiplication.
 trait TensorTrait<T> {
     fn new(shape: Span<usize>, data: Span<T>) -> Tensor<T>;
     fn at(self: @Tensor<T>, indices: Span<usize>) -> T;
@@ -46,7 +46,7 @@ trait TensorTrait<T> {
     fn transpose(self: @Tensor<T>, axes: Span<usize>) -> Tensor<T>;
     fn reduce_sum(self: @Tensor<T>, axis: usize) -> Tensor<T>;
     fn argmax(self: @Tensor<T>, axis: usize) -> Tensor<usize>;
-    fn mul(self: @Tensor<T>, other: @Tensor<T>) -> Tensor<T>;
+    fn matmul(self: @Tensor<T>, other: @Tensor<T>) -> Tensor<T>;
 }
 
 /// Constructs a new tensor with the given shape and data array after checking compatibility.

--- a/src/operators/math/tensor/helpers.cairo
+++ b/src/operators/math/tensor/helpers.cairo
@@ -265,7 +265,9 @@ fn find_axis(mut axes: Span<usize>, target_axis: usize) -> usize {
 ///
 /// # Returns
 /// * A span representing the adjusted shape of the tensor.
-fn prepare_shape_for_mul(mut shape: Span<usize>, is_first_tensor: bool) -> Span<usize> {
+fn prepare_shape_for_matmul(
+    mut shape: Span<usize>, is_first_tensor: bool
+) -> Span<usize> {
     let ndim = shape.len();
 
     if ndim == 1 & is_first_tensor {
@@ -314,7 +316,7 @@ fn prepare_shape_for_mul(mut shape: Span<usize>, is_first_tensor: bool) -> Span<
 ///
 /// # Returns
 /// * A span representing the adjusted output shape of the matrix multiplication result.
-fn adjust_output_shape_after_mul(
+fn adjust_output_shape_after_matmul(
     mut output_shape: Span<usize>, self_dim: usize, other_dim: usize
 ) -> Span<usize> {
     // If self_shape was 1-dimensional, remove the prepended 1 from the output_shape.

--- a/src/operators/math/tensor/helpers.cairo
+++ b/src/operators/math/tensor/helpers.cairo
@@ -316,7 +316,6 @@ fn prepare_shape_for_matmul(
 ///
 /// # Returns
 /// * A span representing the adjusted output shape of the matrix multiplication result.
-
 fn adjust_output_shape_after_matmul(
     mut output_shape: Span<usize>, self_dim: usize, other_dim: usize
 ) -> Span<usize> {

--- a/src/operators/math/tensor/helpers.cairo
+++ b/src/operators/math/tensor/helpers.cairo
@@ -247,3 +247,88 @@ fn find_axis(mut axes: Span<usize>, target_axis: usize) -> usize {
     };
     return axis;
 }
+
+/// Prepares the shapes of two tensors for matrix multiplication.
+///
+/// # Arguments
+/// * `self_shape` - A mutable span representing the shape of the first tensor.
+/// * `other_shape` - A mutable span representing the shape of the second tensor.
+///
+/// # Behavior
+/// This function adjusts the shapes of the tensors based on their dimensionality:
+/// * If the first tensor is 1-dimensional, a 1 is prepended to its shape.
+/// * If the second tensor is 1-dimensional, a 1 is appended to its shape.
+///
+/// # Panics
+/// * Panics if gas limit is exceeded during execution.
+///
+/// # Returns
+/// * A tuple of two spans representing the adjusted shapes of the input tensors.
+fn prepare_shapes_for_matmul(
+    mut self_shape: Span<usize>, mut other_shape: Span<usize>
+) -> (Span<usize>, Span<usize>) {
+    let self_ndim = self_shape.len();
+    let other_ndim = other_shape.len();
+
+    if self_ndim == 1 {
+        // Prepend 1 to self_shape if it's 1-dimensional
+        let mut self_shape_adjusted = ArrayTrait::new();
+        self_shape_adjusted.append(1);
+        loop {
+            check_gas();
+            if self_shape.len() == 0 {
+                break ();
+            }
+            self_shape_adjusted.append(*self_shape.pop_front().unwrap());
+        };
+
+        return (self_shape_adjusted.span(), other_shape);
+    } else if other_ndim == 1 {
+        // Append 1 to other_shape if it's 1-dimensional
+        let mut other_shape_adjusted = ArrayTrait::new();
+        loop {
+            check_gas();
+            if other_shape.len() == 0 {
+                break ();
+            }
+            other_shape_adjusted.append(*other_shape.pop_front().unwrap());
+        };
+        other_shape_adjusted.append(1);
+
+        return (self_shape, other_shape_adjusted.span());
+    }
+
+    return (self_shape, other_shape);
+}
+
+/// Adjusts the output shape of the matrix multiplication result based on the
+/// original dimensionality of the input tensors.
+///
+/// # Arguments
+/// * `output_shape` - A mutable span representing the shape of the matrix multiplication result.
+/// * `self_dim` - A usize representing the dimensionality of the first input tensor.
+/// * `other_dim` - A usize representing the dimensionality of the second input tensor.
+///
+/// # Behavior
+/// This function adjusts the output shape based on the dimensionality of the input tensors:
+/// * If the first input tensor was 1-dimensional, the prepended 1 is removed from the output shape.
+/// * If the second input tensor was 1-dimensional, the appended 1 is removed from the output shape.
+///
+/// # Returns
+/// * A span representing the adjusted output shape of the matrix multiplication result.
+
+fn adjust_output_shape_after_matmul(
+    mut output_shape: Span<usize>, self_dim: usize, other_dim: usize
+) -> Span<usize> {
+    // If self_shape was 1-dimensional, remove the prepended 1 from the output_shape.
+    if self_dim == 1 {
+        let _ = output_shape.pop_front().unwrap();
+    }
+
+    // If other_shape was 1-dimensional, remove the appended 1 from the output_shape.
+    if other_dim == 1 {
+        let _ = output_shape.pop_back().unwrap();
+    }
+
+    return output_shape;
+}

--- a/src/operators/math/tensor/helpers.cairo
+++ b/src/operators/math/tensor/helpers.cairo
@@ -265,9 +265,7 @@ fn find_axis(mut axes: Span<usize>, target_axis: usize) -> usize {
 ///
 /// # Returns
 /// * A span representing the adjusted shape of the tensor.
-fn prepare_shape_for_matmul(
-    mut shape: Span<usize>, is_first_tensor: bool
-) -> Span<usize> {
+fn prepare_shape_for_mul(mut shape: Span<usize>, is_first_tensor: bool) -> Span<usize> {
     let ndim = shape.len();
 
     if ndim == 1 & is_first_tensor {
@@ -316,7 +314,7 @@ fn prepare_shape_for_matmul(
 ///
 /// # Returns
 /// * A span representing the adjusted output shape of the matrix multiplication result.
-fn adjust_output_shape_after_matmul(
+fn adjust_output_shape_after_mul(
     mut output_shape: Span<usize>, self_dim: usize, other_dim: usize
 ) -> Span<usize> {
     // If self_shape was 1-dimensional, remove the prepended 1 from the output_shape.

--- a/src/operators/math/tensor/tensor_i32.cairo
+++ b/src/operators/math/tensor/tensor_i32.cairo
@@ -21,7 +21,7 @@ use onnx_cairo::operators::math::tensor::helpers::len_from_shape;
 use onnx_cairo::operators::math::tensor::helpers::combine_indices;
 use onnx_cairo::operators::math::tensor::helpers::find_axis;
 use onnx_cairo::operators::math::tensor::helpers::permutation_output_shape;
-use onnx_cairo::operators::math::tensor::helpers::prepare_shapes_for_matmul;
+use onnx_cairo::operators::math::tensor::helpers::prepare_shape_for_matmul;
 use onnx_cairo::operators::math::tensor::helpers::adjust_output_shape_after_matmul;
 
 use onnx_cairo::operators::math::tensor::tensor_u32;
@@ -760,11 +760,10 @@ fn i32_matmul(self: @Tensor<i32>, other: @Tensor<i32>) -> Tensor<i32> {
         return TensorTrait::new(result_shape.span(), result_data.span());
     }
 
-    let (self_shape, other_shape) = prepare_shapes_for_matmul(self_shape, other_shape);
+    let self_shape = prepare_shape_for_matmul(self_shape, true);
+    let other_shape = prepare_shape_for_matmul(other_shape, false);
 
-    let result = i32_matrix_multiply(
-        *self.data, self_shape, *other.data, other_shape
-    );
+    let result = i32_matrix_multiply(*self.data, self_shape, *other.data, other_shape);
 
     let result_shape = adjust_output_shape_after_matmul(result.shape, self_ndim, other_ndim);
 

--- a/src/operators/math/tensor/tensor_i32.cairo
+++ b/src/operators/math/tensor/tensor_i32.cairo
@@ -762,13 +762,13 @@ fn i32_matmul(self: @Tensor<i32>, other: @Tensor<i32>) -> Tensor<i32> {
 
     let (self_shape, other_shape) = prepare_shapes_for_matmul(self_shape, other_shape);
 
-    let (result_data, result_shape) = i32_matrix_multiply(
+    let result = i32_matrix_multiply(
         *self.data, self_shape, *other.data, other_shape
     );
 
-    let result_shape = adjust_output_shape_after_matmul(result_shape, self_ndim, other_ndim);
+    let result_shape = adjust_output_shape_after_matmul(result.shape, self_ndim, other_ndim);
 
-    return TensorTrait::<i32>::new(result_shape, result_data);
+    return TensorTrait::<i32>::new(result_shape, result.data);
 }
 
 /// Computes the dot product of two 1-dimensional i32 tensors.
@@ -817,12 +817,10 @@ fn i32_dot_product(mut vec1: Span<i32>, mut vec2: Span<i32>) -> i32 {
 /// * Panics if gas limit is exceeded during execution.
 ///
 /// # Returns
-/// * A Tuple with two elements:
-///   * A new Array containing the data elements of the resulting matrix as i32 elements.
-///   * A new Array containing the shape of the resulting matrix as usize elements.
+/// * Returns the restulting i32 tensor.
 fn i32_matrix_multiply(
     mat1: Span<i32>, mat1_shape: Span<usize>, mat2: Span<i32>, mat2_shape: Span<usize>
-) -> (Span<i32>, Span<usize>) {
+) -> Tensor<i32> {
     let m = *mat1_shape.at(0);
     let n = *mat1_shape.at(1);
     let p = *mat2_shape.at(1);
@@ -868,5 +866,5 @@ fn i32_matrix_multiply(
         i += 1;
     };
 
-    return (result_data.span(), result_shape.span());
+    return TensorTrait::new(result_shape.span(), result_data.span());
 }

--- a/src/operators/math/tensor/tensor_i32.cairo
+++ b/src/operators/math/tensor/tensor_i32.cairo
@@ -21,8 +21,8 @@ use onnx_cairo::operators::math::tensor::helpers::len_from_shape;
 use onnx_cairo::operators::math::tensor::helpers::combine_indices;
 use onnx_cairo::operators::math::tensor::helpers::find_axis;
 use onnx_cairo::operators::math::tensor::helpers::permutation_output_shape;
-use onnx_cairo::operators::math::tensor::helpers::prepare_shape_for_matmul;
-use onnx_cairo::operators::math::tensor::helpers::adjust_output_shape_after_matmul;
+use onnx_cairo::operators::math::tensor::helpers::prepare_shape_for_mul;
+use onnx_cairo::operators::math::tensor::helpers::adjust_output_shape_after_mul;
 use onnx_cairo::operators::math::tensor::tensor_u32;
 use onnx_cairo::utils::check_gas;
 
@@ -216,8 +216,8 @@ impl i32Tensor of TensorTrait<i32> {
     ///
     /// # Returns
     /// * A new `Tensor<i32>` resulting from the matrix multiplication.
-    fn matmul(self: @Tensor<i32>, other: @Tensor<i32>) -> Tensor<i32> {
-        i32_matmul(self, other)
+    fn mul(self: @Tensor<i32>, other: @Tensor<i32>) -> Tensor<i32> {
+        i32_mul(self, other)
     }
 }
 
@@ -741,13 +741,13 @@ fn i32_transpose(self: @Tensor<i32>, axes: Span<usize>) -> Tensor<i32> {
 ///
 /// # Returns
 /// * A new `Tensor<i32>` resulting from the matrix multiplication.
-fn i32_matmul(self: @Tensor<i32>, other: @Tensor<i32>) -> Tensor<i32> {
+fn i32_mul(self: @Tensor<i32>, other: @Tensor<i32>) -> Tensor<i32> {
     let self_shape = *self.shape;
     let other_shape = *other.shape;
     let self_ndim = (self_shape).len();
     let other_ndim = (other_shape).len();
 
-    assert(self_ndim <= 2 | other_ndim <= 2, 'supports only 1D and 2D matmul');
+    assert(self_ndim <= 2 | other_ndim <= 2, 'supports only 1D and 2D mul');
 
     //! Case: Both tensors are 1-dimensional
     if self_ndim == 1 & other_ndim == 1 {
@@ -759,12 +759,12 @@ fn i32_matmul(self: @Tensor<i32>, other: @Tensor<i32>) -> Tensor<i32> {
         return TensorTrait::new(result_shape.span(), result_data.span());
     }
 
-    let self_shape = prepare_shape_for_matmul(self_shape, true);
-    let other_shape = prepare_shape_for_matmul(other_shape, false);
+    let self_shape = prepare_shape_for_mul(self_shape, true);
+    let other_shape = prepare_shape_for_mul(other_shape, false);
 
     let result = i32_matrix_multiply(*self.data, self_shape, *other.data, other_shape);
 
-    let result_shape = adjust_output_shape_after_matmul(result.shape, self_ndim, other_ndim);
+    let result_shape = adjust_output_shape_after_mul(result.shape, self_ndim, other_ndim);
 
     return TensorTrait::<i32>::new(result_shape, result.data);
 }

--- a/src/operators/math/tensor/tensor_i32.cairo
+++ b/src/operators/math/tensor/tensor_i32.cairo
@@ -783,7 +783,7 @@ fn i32_matmul(self: @Tensor<i32>, other: @Tensor<i32>) -> Tensor<i32> {
 ///
 /// # Returns
 /// * An i32 representing the dot product of the two vectors.
-fn i32_dot_product(vec1: Span<i32>, vec2: Span<i32>) -> i32 {
+fn i32_dot_product(mut vec1: Span<i32>, mut vec2: Span<i32>) -> i32 {
     assert(vec1.len() == vec2.len(), 'vector lengths do not match');
 
     let mut result: i32 = IntegerTrait::new(0, false);
@@ -792,13 +792,12 @@ fn i32_dot_product(vec1: Span<i32>, vec2: Span<i32>) -> i32 {
 
     loop {
         check_gas();
-        if idx >= vec_len {
+        if vec1.len() == 0 {
             break ();
         }
 
-        let element_product = *vec1.at(idx) * *vec2.at(idx);
+        let element_product = *vec1.pop_front().unwrap() * *vec2.pop_front().unwrap();
         result += element_product;
-        idx += 1;
     };
 
     return result;

--- a/src/operators/math/tensor/tensor_i32.cairo
+++ b/src/operators/math/tensor/tensor_i32.cairo
@@ -23,7 +23,6 @@ use onnx_cairo::operators::math::tensor::helpers::find_axis;
 use onnx_cairo::operators::math::tensor::helpers::permutation_output_shape;
 use onnx_cairo::operators::math::tensor::helpers::prepare_shape_for_matmul;
 use onnx_cairo::operators::math::tensor::helpers::adjust_output_shape_after_matmul;
-
 use onnx_cairo::operators::math::tensor::tensor_u32;
 use onnx_cairo::utils::check_gas;
 

--- a/src/operators/math/tensor/tensor_i32.cairo
+++ b/src/operators/math/tensor/tensor_i32.cairo
@@ -21,8 +21,8 @@ use onnx_cairo::operators::math::tensor::helpers::len_from_shape;
 use onnx_cairo::operators::math::tensor::helpers::combine_indices;
 use onnx_cairo::operators::math::tensor::helpers::find_axis;
 use onnx_cairo::operators::math::tensor::helpers::permutation_output_shape;
-use onnx_cairo::operators::math::tensor::helpers::prepare_shape_for_mul;
-use onnx_cairo::operators::math::tensor::helpers::adjust_output_shape_after_mul;
+use onnx_cairo::operators::math::tensor::helpers::prepare_shape_for_matmul;
+use onnx_cairo::operators::math::tensor::helpers::adjust_output_shape_after_matmul;
 use onnx_cairo::operators::math::tensor::tensor_u32;
 use onnx_cairo::utils::check_gas;
 
@@ -216,8 +216,8 @@ impl i32Tensor of TensorTrait<i32> {
     ///
     /// # Returns
     /// * A new `Tensor<i32>` resulting from the matrix multiplication.
-    fn mul(self: @Tensor<i32>, other: @Tensor<i32>) -> Tensor<i32> {
-        i32_mul(self, other)
+    fn matmul(self: @Tensor<i32>, other: @Tensor<i32>) -> Tensor<i32> {
+        i32_matmul(self, other)
     }
 }
 
@@ -741,13 +741,13 @@ fn i32_transpose(self: @Tensor<i32>, axes: Span<usize>) -> Tensor<i32> {
 ///
 /// # Returns
 /// * A new `Tensor<i32>` resulting from the matrix multiplication.
-fn i32_mul(self: @Tensor<i32>, other: @Tensor<i32>) -> Tensor<i32> {
+fn i32_matmul(self: @Tensor<i32>, other: @Tensor<i32>) -> Tensor<i32> {
     let self_shape = *self.shape;
     let other_shape = *other.shape;
     let self_ndim = (self_shape).len();
     let other_ndim = (other_shape).len();
 
-    assert(self_ndim <= 2 | other_ndim <= 2, 'supports only 1D and 2D mul');
+    assert(self_ndim <= 2 | other_ndim <= 2, 'supports only 1D and 2D matmul');
 
     //! Case: Both tensors are 1-dimensional
     if self_ndim == 1 & other_ndim == 1 {
@@ -759,12 +759,12 @@ fn i32_mul(self: @Tensor<i32>, other: @Tensor<i32>) -> Tensor<i32> {
         return TensorTrait::new(result_shape.span(), result_data.span());
     }
 
-    let self_shape = prepare_shape_for_mul(self_shape, true);
-    let other_shape = prepare_shape_for_mul(other_shape, false);
+    let self_shape = prepare_shape_for_matmul(self_shape, true);
+    let other_shape = prepare_shape_for_matmul(other_shape, false);
 
     let result = i32_matrix_multiply(*self.data, self_shape, *other.data, other_shape);
 
-    let result_shape = adjust_output_shape_after_mul(result.shape, self_ndim, other_ndim);
+    let result_shape = adjust_output_shape_after_matmul(result.shape, self_ndim, other_ndim);
 
     return TensorTrait::<i32>::new(result_shape, result.data);
 }

--- a/src/operators/math/tensor/tensor_u32.cairo
+++ b/src/operators/math/tensor/tensor_u32.cairo
@@ -774,7 +774,7 @@ fn u32_matmul(self: @Tensor<u32>, other: @Tensor<u32>) -> Tensor<u32> {
 ///
 /// # Returns
 /// * An u32 representing the dot product of the two vectors.
-fn u32_dot_product(vec1: Span<u32>, vec2: Span<u32>) -> u32 {
+fn u32_dot_product(mut vec1: Span<u32>, mut vec2: Span<u32>) -> u32 {
     assert(vec1.len() == vec2.len(), 'vector lengths do not match');
 
     let mut result: u32 = 0;
@@ -783,11 +783,11 @@ fn u32_dot_product(vec1: Span<u32>, vec2: Span<u32>) -> u32 {
 
     loop {
         check_gas();
-        if idx >= vec_len {
+        if vec1.len() == 0 {
             break ();
         }
 
-        let element_product = *vec1.at(idx) * *vec2.at(idx);
+        let element_product = *vec1.pop_front().unwrap() * *vec2.pop_front().unwrap();
         result += element_product;
         idx += 1;
     };

--- a/src/operators/math/tensor/tensor_u32.cairo
+++ b/src/operators/math/tensor/tensor_u32.cairo
@@ -19,6 +19,8 @@ use onnx_cairo::operators::math::tensor::helpers::len_from_shape;
 use onnx_cairo::operators::math::tensor::helpers::combine_indices;
 use onnx_cairo::operators::math::tensor::helpers::find_axis;
 use onnx_cairo::operators::math::tensor::helpers::permutation_output_shape;
+use onnx_cairo::operators::math::tensor::helpers::prepare_shapes_for_matmul;
+use onnx_cairo::operators::math::tensor::helpers::adjust_output_shape_after_matmul;
 use onnx_cairo::utils::check_gas;
 
 impl U32Tensor of TensorTrait<u32> {
@@ -188,6 +190,31 @@ impl U32Tensor of TensorTrait<u32> {
     /// * A new `Tensor<u32>` instance with the axes transposed according to the specified order.
     fn transpose(self: @Tensor<u32>, axes: Span<usize>) -> Tensor<u32> {
         u32_transpose(self, axes)
+    }
+
+    /// Performs matrix multiplication between two u32 tensors.
+    ///
+    /// # Arguments
+    /// * `self` - The first tensor.
+    /// * `other` - The second tensor.
+    ///
+    /// # Behavior
+    /// The behavior depends on the dimensionality of the tensors as follows:
+    /// * If both tensors are 1-dimensional, the dot product is returned.
+    /// * If both arguments are 2-dimensional, the matrix-matrix product is returned.
+    /// * If the first argument is 1-dimensional and the second argument is 2-dimensional,
+    ///   a 1 is prepended to its dimension for the purpose of the matrix multiply. After
+    ///   the matrix multiply, the prepended dimension is removed.
+    /// * If the first argument is 2-dimensional and the second argument is 1-dimensional,
+    ///   the matrix-vector product is returned.
+    ///
+    /// # Panics
+    /// * Panics if the dimension of the tensors is higher than two.
+    ///
+    /// # Returns
+    /// * A new `Tensor<u32>` resulting from the matrix multiplication.
+    fn matmul(self: @Tensor<u32>, other: @Tensor<u32>) -> Tensor<u32> {
+        u32_matmul(self, other)
     }
 }
 
@@ -682,4 +709,156 @@ fn u32_transpose(self: @Tensor<u32>, axes: Span<usize>) -> Tensor<u32> {
     };
 
     return TensorTrait::<u32>::new(output_shape, output_data.span());
+}
+
+
+/// Performs matrix multiplication between two u32 tensors.
+///
+/// # Arguments
+/// * `self` - The first tensor.
+/// * `other` - The second tensor.
+///
+/// # Behavior
+/// The behavior depends on the dimensionality of the tensors as follows:
+/// * If both tensors are 1-dimensional, the dot product is returned.
+/// * If both arguments are 2-dimensional, the matrix-matrix product is returned.
+/// * If the first argument is 1-dimensional and the second argument is 2-dimensional,
+///   a 1 is prepended to its dimension for the purpose of the matrix multiply. After
+///   the matrix multiply, the prepended dimension is removed.
+/// * If the first argument is 2-dimensional and the second argument is 1-dimensional,
+///   the matrix-vector product is returned.
+///
+/// # Panics
+/// * Panics if the dimension of the tensors is higher than two.
+///
+/// # Returns
+/// * A new `Tensor<u32>` resulting from the matrix multiplication.
+fn u32_matmul(self: @Tensor<u32>, other: @Tensor<u32>) -> Tensor<u32> {
+    let self_shape = *self.shape;
+    let other_shape = *other.shape;
+    let self_ndim = (self_shape).len();
+    let other_ndim = (other_shape).len();
+
+    assert(self_ndim <= 2 | other_ndim <= 2, 'supports only 1D and 2D matmul');
+
+    //! Case: Both tensors are 1-dimensional
+    if self_ndim == 1 & other_ndim == 1 {
+        let dot = u32_dot_product((*self).data, (*other).data);
+        let mut result_shape = ArrayTrait::new();
+        let mut result_data = ArrayTrait::new();
+        result_shape.append(1);
+        result_data.append(dot);
+        return TensorTrait::new(result_shape.span(), result_data.span());
+    }
+
+    let (self_shape, other_shape) = prepare_shapes_for_matmul(self_shape, other_shape);
+
+    let (result_data, result_shape) = u32_matrix_multiply(
+        *self.data, self_shape, *other.data, other_shape
+    );
+
+    let result_shape = adjust_output_shape_after_matmul(result_shape, self_ndim, other_ndim);
+
+    return TensorTrait::<u32>::new(result_shape, result_data);
+}
+
+/// Computes the dot product of two 1-dimensional u32 tensors.
+///
+/// # Arguments
+/// * `vec1` - A span containing the data elements of the first vector as u32 elements.
+/// * `vec2` - A span containing the data elements of the second vector as u32 elements.
+///
+/// # Panics
+/// * Panics if the lengths of the vectors do not match.
+/// * Panics if gas limit is exceeded during execution.
+///
+/// # Returns
+/// * An u32 representing the dot product of the two vectors.
+fn u32_dot_product(vec1: Span<u32>, vec2: Span<u32>) -> u32 {
+    assert(vec1.len() == vec2.len(), 'vector lengths do not match');
+
+    let mut result: u32 = 0;
+    let vec_len = vec1.len();
+    let mut idx: usize = 0;
+
+    loop {
+        check_gas();
+        if idx >= vec_len {
+            break ();
+        }
+
+        let element_product = *vec1.at(idx) * *vec2.at(idx);
+        result += element_product;
+        idx += 1;
+    };
+
+    return result;
+}
+
+
+/// Computes the matrix multiplication of two 2-dimensional u32 tensors.
+///
+/// # Arguments
+/// * `mat1` - A Span containing the data elements of the first matrix as u32 elements.
+/// * `mat1_shape` - A Span containing the shape of the first matrix as usize elements.
+/// * `mat2` - A Span containing the data elements of the second matrix as u32 elements.
+/// * `mat2_shape` - A Span containing the shape of the second matrix as usize elements.
+///
+/// # Panics
+/// * Panics if the inner dimensions of the matrices do not match.
+/// * Panics if gas limit is exceeded during execution.
+///
+/// # Returns
+/// * A Tuple with two elements:
+///   * A new Array containing the data elements of the resulting matrix as u32 elements.
+///   * A new Array containing the shape of the resulting matrix as usize elements.
+fn u32_matrix_multiply(
+    mat1: Span<u32>, mat1_shape: Span<usize>, mat2: Span<u32>, mat2_shape: Span<usize>
+) -> (Span<u32>, Span<usize>) {
+    let m = *mat1_shape.at(0);
+    let n = *mat1_shape.at(1);
+    let p = *mat2_shape.at(1);
+
+    let mut result_data = ArrayTrait::new();
+    let mut result_shape = ArrayTrait::new();
+    result_shape.append(m);
+    result_shape.append(p);
+
+    let mut i = 0_usize;
+    loop {
+        check_gas();
+        if i == m {
+            break ();
+        }
+
+        let mut j = 0_usize;
+        loop {
+            check_gas();
+            if j == p {
+                break ();
+            }
+
+            let mut sum: u32 = 0;
+            let mut k = 0_usize;
+            loop {
+                check_gas();
+                if k == n {
+                    break ();
+                }
+
+                let mat1_index = i * n + k;
+                let mat2_index = k * p + j;
+                sum += *mat1.at(mat1_index) * *mat2.at(mat2_index);
+
+                k += 1;
+            };
+
+            result_data.append(sum);
+            j += 1;
+        };
+
+        i += 1;
+    };
+
+    return (result_data.span(), result_shape.span());
 }

--- a/src/operators/math/tensor/tensor_u32.cairo
+++ b/src/operators/math/tensor/tensor_u32.cairo
@@ -19,8 +19,8 @@ use onnx_cairo::operators::math::tensor::helpers::len_from_shape;
 use onnx_cairo::operators::math::tensor::helpers::combine_indices;
 use onnx_cairo::operators::math::tensor::helpers::find_axis;
 use onnx_cairo::operators::math::tensor::helpers::permutation_output_shape;
-use onnx_cairo::operators::math::tensor::helpers::prepare_shape_for_matmul;
-use onnx_cairo::operators::math::tensor::helpers::adjust_output_shape_after_matmul;
+use onnx_cairo::operators::math::tensor::helpers::prepare_shape_for_mul;
+use onnx_cairo::operators::math::tensor::helpers::adjust_output_shape_after_mul;
 use onnx_cairo::utils::check_gas;
 
 impl U32Tensor of TensorTrait<u32> {
@@ -213,8 +213,8 @@ impl U32Tensor of TensorTrait<u32> {
     ///
     /// # Returns
     /// * A new `Tensor<u32>` resulting from the matrix multiplication.
-    fn matmul(self: @Tensor<u32>, other: @Tensor<u32>) -> Tensor<u32> {
-        u32_matmul(self, other)
+    fn mul(self: @Tensor<u32>, other: @Tensor<u32>) -> Tensor<u32> {
+        u32_mul(self, other)
     }
 }
 
@@ -733,13 +733,13 @@ fn u32_transpose(self: @Tensor<u32>, axes: Span<usize>) -> Tensor<u32> {
 ///
 /// # Returns
 /// * A new `Tensor<u32>` resulting from the matrix multiplication.
-fn u32_matmul(self: @Tensor<u32>, other: @Tensor<u32>) -> Tensor<u32> {
+fn u32_mul(self: @Tensor<u32>, other: @Tensor<u32>) -> Tensor<u32> {
     let self_shape = *self.shape;
     let other_shape = *other.shape;
     let self_ndim = (self_shape).len();
     let other_ndim = (other_shape).len();
 
-    assert(self_ndim <= 2 | other_ndim <= 2, 'supports only 1D and 2D matmul');
+    assert(self_ndim <= 2 | other_ndim <= 2, 'supports only 1D and 2D mul');
 
     //! Case: Both tensors are 1-dimensional
     if self_ndim == 1 & other_ndim == 1 {
@@ -751,14 +751,12 @@ fn u32_matmul(self: @Tensor<u32>, other: @Tensor<u32>) -> Tensor<u32> {
         return TensorTrait::new(result_shape.span(), result_data.span());
     }
 
-    let self_shape = prepare_shape_for_matmul(self_shape, true);
-    let other_shape = prepare_shape_for_matmul(other_shape, false);
+    let self_shape = prepare_shape_for_mul(self_shape, true);
+    let other_shape = prepare_shape_for_mul(other_shape, false);
 
-    let result = u32_matrix_multiply(
-        *self.data, self_shape, *other.data, other_shape
-    );
+    let result = u32_matrix_multiply(*self.data, self_shape, *other.data, other_shape);
 
-    let result_shape = adjust_output_shape_after_matmul(result.shape, self_ndim, other_ndim);
+    let result_shape = adjust_output_shape_after_mul(result.shape, self_ndim, other_ndim);
 
     return TensorTrait::<u32>::new(result_shape, result.data);
 }

--- a/src/operators/math/tensor/tensor_u32.cairo
+++ b/src/operators/math/tensor/tensor_u32.cairo
@@ -19,7 +19,7 @@ use onnx_cairo::operators::math::tensor::helpers::len_from_shape;
 use onnx_cairo::operators::math::tensor::helpers::combine_indices;
 use onnx_cairo::operators::math::tensor::helpers::find_axis;
 use onnx_cairo::operators::math::tensor::helpers::permutation_output_shape;
-use onnx_cairo::operators::math::tensor::helpers::prepare_shapes_for_matmul;
+use onnx_cairo::operators::math::tensor::helpers::prepare_shape_for_matmul;
 use onnx_cairo::operators::math::tensor::helpers::adjust_output_shape_after_matmul;
 use onnx_cairo::utils::check_gas;
 
@@ -751,7 +751,8 @@ fn u32_matmul(self: @Tensor<u32>, other: @Tensor<u32>) -> Tensor<u32> {
         return TensorTrait::new(result_shape.span(), result_data.span());
     }
 
-    let (self_shape, other_shape) = prepare_shapes_for_matmul(self_shape, other_shape);
+    let self_shape = prepare_shape_for_matmul(self_shape, true);
+    let other_shape = prepare_shape_for_matmul(other_shape, false);
 
     let result = u32_matrix_multiply(
         *self.data, self_shape, *other.data, other_shape

--- a/src/operators/math/tensor/tensor_u32.cairo
+++ b/src/operators/math/tensor/tensor_u32.cairo
@@ -753,13 +753,13 @@ fn u32_matmul(self: @Tensor<u32>, other: @Tensor<u32>) -> Tensor<u32> {
 
     let (self_shape, other_shape) = prepare_shapes_for_matmul(self_shape, other_shape);
 
-    let (result_data, result_shape) = u32_matrix_multiply(
+    let result = u32_matrix_multiply(
         *self.data, self_shape, *other.data, other_shape
     );
 
-    let result_shape = adjust_output_shape_after_matmul(result_shape, self_ndim, other_ndim);
+    let result_shape = adjust_output_shape_after_matmul(result.shape, self_ndim, other_ndim);
 
-    return TensorTrait::<u32>::new(result_shape, result_data);
+    return TensorTrait::<u32>::new(result_shape, result.data);
 }
 
 /// Computes the dot product of two 1-dimensional u32 tensors.
@@ -809,12 +809,10 @@ fn u32_dot_product(mut vec1: Span<u32>, mut vec2: Span<u32>) -> u32 {
 /// * Panics if gas limit is exceeded during execution.
 ///
 /// # Returns
-/// * A Tuple with two elements:
-///   * A new Array containing the data elements of the resulting matrix as u32 elements.
-///   * A new Array containing the shape of the resulting matrix as usize elements.
+/// * Returns the restulting u32 tensor.
 fn u32_matrix_multiply(
     mat1: Span<u32>, mat1_shape: Span<usize>, mat2: Span<u32>, mat2_shape: Span<usize>
-) -> (Span<u32>, Span<usize>) {
+) -> Tensor<u32> {
     let m = *mat1_shape.at(0);
     let n = *mat1_shape.at(1);
     let p = *mat2_shape.at(1);
@@ -860,5 +858,5 @@ fn u32_matrix_multiply(
         i += 1;
     };
 
-    return (result_data.span(), result_shape.span());
+    return TensorTrait::new(result_shape.span(), result_data.span());
 }

--- a/src/tests/tensor_test.cairo
+++ b/src/tests/tensor_test.cairo
@@ -5,8 +5,6 @@ use traits::Into;
 use onnx_cairo::operators::math::signed_integer::IntegerTrait;
 use onnx_cairo::operators::math::signed_integer::i32;
 use onnx_cairo::operators::math::tensor::tensor_i32;
-use onnx_cairo::operators::math::tensor::tensor_i32::matmul;
-use onnx_cairo::operators::math::tensor::tensor_i32::dot_product;
 use onnx_cairo::operators::math::tensor::core::TensorTrait;
 use onnx_cairo::operators::math::tensor::core::Tensor;
 use onnx_cairo::operators::math::tensor::core::ravel_index;
@@ -594,7 +592,7 @@ fn tensor_matmul() {
     let tensor_1 = i32_tensor_1x3_helper();
     let tensor_2 = i32_tensor_1x3_helper();
 
-    let result = matmul(tensor_1, tensor_2);
+    let result = tensor_1.matmul(@tensor_2);
     assert(*result.data.at(0).mag == 5, 'result[0] = 5');
     assert(result.data.len() == 1, 'data len is 1');
     assert(result.shape.len() == 1, 'shape len is 1');
@@ -603,7 +601,7 @@ fn tensor_matmul() {
     let tensor_1 = i32_tensor_2x2_helper();
     let tensor_2 = i32_tensor_2x2_helper();
 
-    let result = matmul(tensor_1, tensor_2);
+    let result = tensor_1.matmul(@tensor_2);
     assert(*result.data.at(0).mag == 2, 'result[0] = 2');
     assert(*result.data.at(1).mag == 3, 'result[1] = 3');
     assert(*result.data.at(2).mag == 6, 'result[2] = 6');
@@ -615,7 +613,7 @@ fn tensor_matmul() {
     let tensor_1 = i32_tensor_3x3_helper();
     let tensor_2 = i32_tensor_1x3_helper();
 
-    let result = matmul(tensor_1, tensor_2);
+    let result = tensor_1.matmul(@tensor_2);
     assert(*result.data.at(0).mag == 5, 'result[0] = 5');
     assert(*result.data.at(1).mag == 14, 'result[1] = 14');
     assert(*result.data.at(2).mag == 23, 'result[2] = 23');
@@ -626,7 +624,7 @@ fn tensor_matmul() {
     let tensor_1 = i32_tensor_1x3_helper();
     let tensor_2 = i32_tensor_3x3_helper();
 
-    let result = matmul(tensor_1, tensor_2);
+    let result = tensor_1.matmul(@tensor_2);
     assert(*result.data.at(0).mag == 15, 'result[0] = 15');
     assert(*result.data.at(1).mag == 18, 'result[1] = 18');
     assert(*result.data.at(2).mag == 21, 'result[2] = 21');

--- a/src/tests/tensor_test.cairo
+++ b/src/tests/tensor_test.cairo
@@ -588,7 +588,7 @@ fn tensor_transpose_3D() {
 #[test]
 #[available_gas(200000000)]
 fn tensor_matmul() {
-    //! Case 1: Dot product (1D x 1D)
+    //! Case: Dot product (1D x 1D)
     let tensor_1 = i32_tensor_1x3_helper();
     let tensor_2 = i32_tensor_1x3_helper();
 
@@ -597,7 +597,7 @@ fn tensor_matmul() {
     assert(result.data.len() == 1, 'data len is 1');
     assert(result.shape.len() == 1, 'shape len is 1');
 
-    //! Case 2: Matrix multiplication (2D x 2D)
+    //! Case: Matrix multiplication (2D x 2D)
     let tensor_1 = i32_tensor_2x2_helper();
     let tensor_2 = i32_tensor_2x2_helper();
 
@@ -608,8 +608,12 @@ fn tensor_matmul() {
     assert(*result.data.at(3).mag == 11, 'result[3] = 11');
     assert(result.data.len() == 4, 'data len is 4');
     assert(result.shape.len() == 2, 'shape len is 2');
+}
 
-    //! Case 3: Matrix-Vector multiplication (2D x 1D)
+#[test]
+#[available_gas(200000000)]
+fn tensor_matmul_with_matrix_vec() {
+    //! Case: Matrix-Vector multiplication (2D x 1D)
     let tensor_1 = i32_tensor_3x3_helper();
     let tensor_2 = i32_tensor_1x3_helper();
 
@@ -620,7 +624,7 @@ fn tensor_matmul() {
     assert(result.data.len() == 3, 'data len is 3');
     assert(result.shape.len() == 1, 'shape len is 1');
 
-    //! Case 4: Matrix-Vector multiplication (1D x 2D)
+    //! Case: Matrix-Vector multiplication (1D x 2D)
     let tensor_1 = i32_tensor_1x3_helper();
     let tensor_2 = i32_tensor_3x3_helper();
 

--- a/src/tests/tensor_test.cairo
+++ b/src/tests/tensor_test.cairo
@@ -587,12 +587,12 @@ fn tensor_transpose_3D() {
 
 #[test]
 #[available_gas(200000000)]
-fn tensor_mul() {
+fn tensor_matmul() {
     //! Case: Dot product (1D x 1D)
     let tensor_1 = i32_tensor_1x3_helper();
     let tensor_2 = i32_tensor_1x3_helper();
 
-    let result = tensor_1.mul(@tensor_2);
+    let result = tensor_1.matmul(@tensor_2);
     assert(*result.data.at(0).mag == 5, 'result[0] = 5');
     assert(result.data.len() == 1, 'data len is 1');
     assert(result.shape.len() == 1, 'shape len is 1');
@@ -601,7 +601,7 @@ fn tensor_mul() {
     let tensor_1 = i32_tensor_2x2_helper();
     let tensor_2 = i32_tensor_2x2_helper();
 
-    let result = tensor_1.mul(@tensor_2);
+    let result = tensor_1.matmul(@tensor_2);
     assert(*result.data.at(0).mag == 2, 'result[0] = 2');
     assert(*result.data.at(1).mag == 3, 'result[1] = 3');
     assert(*result.data.at(2).mag == 6, 'result[2] = 6');
@@ -612,12 +612,12 @@ fn tensor_mul() {
 
 #[test]
 #[available_gas(200000000)]
-fn tensor_mul_with_matrix_vec() {
+fn tensor_matmul_with_matrix_vec() {
     //! Case: Matrix-Vector multiplication (2D x 1D)
     let tensor_1 = i32_tensor_3x3_helper();
     let tensor_2 = i32_tensor_1x3_helper();
 
-    let result = tensor_1.mul(@tensor_2);
+    let result = tensor_1.matmul(@tensor_2);
     assert(*result.data.at(0).mag == 5, 'result[0] = 5');
     assert(*result.data.at(1).mag == 14, 'result[1] = 14');
     assert(*result.data.at(2).mag == 23, 'result[2] = 23');
@@ -628,7 +628,7 @@ fn tensor_mul_with_matrix_vec() {
     let tensor_1 = i32_tensor_1x3_helper();
     let tensor_2 = i32_tensor_3x3_helper();
 
-    let result = tensor_1.mul(@tensor_2);
+    let result = tensor_1.matmul(@tensor_2);
     assert(*result.data.at(0).mag == 15, 'result[0] = 15');
     assert(*result.data.at(1).mag == 18, 'result[1] = 18');
     assert(*result.data.at(2).mag == 21, 'result[2] = 21');

--- a/src/tests/tensor_test.cairo
+++ b/src/tests/tensor_test.cairo
@@ -587,12 +587,12 @@ fn tensor_transpose_3D() {
 
 #[test]
 #[available_gas(200000000)]
-fn tensor_matmul() {
+fn tensor_mul() {
     //! Case: Dot product (1D x 1D)
     let tensor_1 = i32_tensor_1x3_helper();
     let tensor_2 = i32_tensor_1x3_helper();
 
-    let result = tensor_1.matmul(@tensor_2);
+    let result = tensor_1.mul(@tensor_2);
     assert(*result.data.at(0).mag == 5, 'result[0] = 5');
     assert(result.data.len() == 1, 'data len is 1');
     assert(result.shape.len() == 1, 'shape len is 1');
@@ -601,7 +601,7 @@ fn tensor_matmul() {
     let tensor_1 = i32_tensor_2x2_helper();
     let tensor_2 = i32_tensor_2x2_helper();
 
-    let result = tensor_1.matmul(@tensor_2);
+    let result = tensor_1.mul(@tensor_2);
     assert(*result.data.at(0).mag == 2, 'result[0] = 2');
     assert(*result.data.at(1).mag == 3, 'result[1] = 3');
     assert(*result.data.at(2).mag == 6, 'result[2] = 6');
@@ -612,12 +612,12 @@ fn tensor_matmul() {
 
 #[test]
 #[available_gas(200000000)]
-fn tensor_matmul_with_matrix_vec() {
+fn tensor_mul_with_matrix_vec() {
     //! Case: Matrix-Vector multiplication (2D x 1D)
     let tensor_1 = i32_tensor_3x3_helper();
     let tensor_2 = i32_tensor_1x3_helper();
 
-    let result = tensor_1.matmul(@tensor_2);
+    let result = tensor_1.mul(@tensor_2);
     assert(*result.data.at(0).mag == 5, 'result[0] = 5');
     assert(*result.data.at(1).mag == 14, 'result[1] = 14');
     assert(*result.data.at(2).mag == 23, 'result[2] = 23');
@@ -628,7 +628,7 @@ fn tensor_matmul_with_matrix_vec() {
     let tensor_1 = i32_tensor_1x3_helper();
     let tensor_2 = i32_tensor_3x3_helper();
 
-    let result = tensor_1.matmul(@tensor_2);
+    let result = tensor_1.mul(@tensor_2);
     assert(*result.data.at(0).mag == 15, 'result[0] = 15');
     assert(*result.data.at(1).mag == 18, 'result[1] = 18');
     assert(*result.data.at(2).mag == 21, 'result[2] = 21');

--- a/src/tests/tensor_test.cairo
+++ b/src/tests/tensor_test.cairo
@@ -5,6 +5,8 @@ use traits::Into;
 use onnx_cairo::operators::math::signed_integer::IntegerTrait;
 use onnx_cairo::operators::math::signed_integer::i32;
 use onnx_cairo::operators::math::tensor::tensor_i32;
+use onnx_cairo::operators::math::tensor::tensor_i32::matmul;
+use onnx_cairo::operators::math::tensor::tensor_i32::dot_product;
 use onnx_cairo::operators::math::tensor::core::TensorTrait;
 use onnx_cairo::operators::math::tensor::core::Tensor;
 use onnx_cairo::operators::math::tensor::core::ravel_index;
@@ -585,6 +587,68 @@ fn tensor_transpose_3D() {
     assert(*result.shape.at(2) == 2, 'shape[2] = 2');
 }
 
+#[test]
+#[available_gas(200000000)]
+fn tensor_matmul() {
+    //! Case 1: Dot product (1D x 1D)
+    let tensor_1 = i32_tensor_1x3_helper();
+    let tensor_2 = i32_tensor_1x3_helper();
+
+    let result = matmul(tensor_1, tensor_2);
+    assert(*result.data.at(0).mag == 5, 'result[0] = 5');
+    assert(result.data.len() == 1, 'data len is 1');
+    assert(result.shape.len() == 1, 'shape len is 1');
+
+    //! Case 2: Matrix multiplication (2D x 2D)
+    let tensor_1 = i32_tensor_2x2_helper();
+    let tensor_2 = i32_tensor_2x2_helper();
+
+    let result = matmul(tensor_1, tensor_2);
+    assert(*result.data.at(0).mag == 2, 'result[0] = 2');
+    assert(*result.data.at(1).mag == 3, 'result[1] = 3');
+    assert(*result.data.at(2).mag == 6, 'result[2] = 6');
+    assert(*result.data.at(3).mag == 11, 'result[3] = 11');
+    assert(result.data.len() == 4, 'data len is 4');
+    assert(result.shape.len() == 2, 'shape len is 2');
+
+    //! Case 3: Matrix-Vector multiplication (2D x 1D)
+    let tensor_1 = i32_tensor_3x3_helper();
+    let tensor_2 = i32_tensor_1x3_helper();
+
+    let result = matmul(tensor_1, tensor_2);
+    assert(*result.data.at(0).mag == 5, 'result[0] = 5');
+    assert(*result.data.at(1).mag == 14, 'result[1] = 14');
+    assert(*result.data.at(2).mag == 23, 'result[2] = 23');
+    assert(result.data.len() == 3, 'data len is 3');
+    assert(result.shape.len() == 1, 'shape len is 1');
+
+    //! Case 4: Matrix-Vector multiplication (1D x 2D)
+    let tensor_1 = i32_tensor_1x3_helper();
+    let tensor_2 = i32_tensor_3x3_helper();
+
+    let result = matmul(tensor_1, tensor_2);
+    assert(*result.data.at(0).mag == 15, 'result[0] = 15');
+    assert(*result.data.at(1).mag == 18, 'result[1] = 18');
+    assert(*result.data.at(2).mag == 21, 'result[2] = 21');
+    assert(result.data.len() == 3, 'data len is 3');
+    assert(result.shape.len() == 1, 'shape len is 1');
+}
+
+// 1D - Helpers
+fn i32_tensor_1x3_helper() -> Tensor<i32> {
+    let mut sizes = ArrayTrait::new();
+    sizes.append(3);
+
+    let mut data = ArrayTrait::new();
+    data.append(IntegerTrait::new(0_u32, false));
+    data.append(IntegerTrait::new(1_u32, false));
+    data.append(IntegerTrait::new(2_u32, false));
+
+    let tensor = TensorTrait::<i32>::new(sizes.span(), data.span());
+
+    return tensor;
+}
+
 // 2D - Helpers
 
 fn i32_tensor_2x2_helper() -> Tensor<i32> {
@@ -597,6 +661,27 @@ fn i32_tensor_2x2_helper() -> Tensor<i32> {
     data.append(IntegerTrait::new(1_u32, false));
     data.append(IntegerTrait::new(2_u32, false));
     data.append(IntegerTrait::new(3_u32, false));
+
+    let tensor = TensorTrait::<i32>::new(sizes.span(), data.span());
+
+    return tensor;
+}
+
+fn i32_tensor_3x3_helper() -> Tensor<i32> {
+    let mut sizes = ArrayTrait::new();
+    sizes.append(3);
+    sizes.append(3);
+
+    let mut data = ArrayTrait::new();
+    data.append(IntegerTrait::new(0_u32, false));
+    data.append(IntegerTrait::new(1_u32, false));
+    data.append(IntegerTrait::new(2_u32, false));
+    data.append(IntegerTrait::new(3_u32, false));
+    data.append(IntegerTrait::new(4_u32, false));
+    data.append(IntegerTrait::new(5_u32, false));
+    data.append(IntegerTrait::new(6_u32, false));
+    data.append(IntegerTrait::new(7_u32, false));
+    data.append(IntegerTrait::new(8_u32, false));
 
     let tensor = TensorTrait::<i32>::new(sizes.span(), data.span());
 


### PR DESCRIPTION
### Feat: tensor.matmul

## Pull Request type

Please check the type of change your PR introduces:

- [ ] Bugfix
- [X] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

- Currently, there is no implementation of matmul

## What is the new behavior?
Performs matrix multiplication between two tensors.

The behavior depends on the dimensionality of the tensors as follows:
* If both tensors are 1-dimensional, the dot product is returned.
* If both arguments are 2-dimensional, the matrix-matrix product is returned.
* If the first argument is 1-dimensional and the second argument is 2-dimensional,  a 1 is prepended to its dimension for the purpose of the matrix multiply. After the matrix multiply, the prepended dimension is removed.
* If the first argument is 2-dimensional and the second argument is 1-dimensional, the matrix-vector product is returned.
* More than 2D matmul is not supported

## Does this introduce a breaking change?

- [ ] Yes
- [X] No

<!-- If this does introduce a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

<!-- Any other information that is important to this PR, such as screenshots of how the component looks before and after the change. -->
