### PR TITLE
Feat: Softmax & Tensor.exp()

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased] - 2023-05-04
+
+### Fixed
+
+- Broadcast operations (add/sub/mul/div)
+
+
 ## [Unreleased] - 2023-05-02
 
 ### Added

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased] - 2023-05-05
+
+### Added
+
+- Added exponential element-wise operation
+- Added softmax 
+
 ## [Unreleased] - 2023-05-04
 
 ### Fixed

--- a/docs/readme/knowledge_base/how_to.md
+++ b/docs/readme/knowledge_base/how_to.md
@@ -11,24 +11,38 @@ src
 │   ├── linalg
 │   │   ├── matmul
 │   │   │   ├── helpers.cairo
+│   │   │   ├── matmul_fp.cairo
 │   │   │   ├── matmul_i32.cairo
 │   │   │   └── matmul_u32.cairo
 │   │   └── matmul.cairo
 │   ├── linalg.cairo
 │   ├── math
 │   │   ├── argmax
+│   │   │   ├── argmax_fp.cairo
 │   │   │   ├── argmax_i32.cairo
 │   │   │   └── argmax_u32.cairo
 │   │   ├── argmax.cairo
+│   │   ├── exp
+│   │   │   ├── exp_fp.cairo
+│   │   │   ├── exp_i32.cairo
+│   │   │   └── exp_u32.cairo
+│   │   ├── exp.cairo
+│   │   ├── fixed_point
+│   │   │   ├── core.cairo
+│   │   │   └── types.cairo
+│   │   ├── fixed_point.cairo
 │   │   ├── max
+│   │   │   ├── max_fp.cairo
 │   │   │   ├── max_i32.cairo
 │   │   │   └── max_u32.cairo
 │   │   ├── max.cairo
 │   │   ├── min
+│   │   │   ├── min_fp.cairo
 │   │   │   ├── min_i32.cairo
 │   │   │   └── min_u32.cairo
 │   │   ├── min.cairo
 │   │   ├── reduce_sum
+│   │   │   ├── reduce_sum_fp.cairo
 │   │   │   ├── reduce_sum_i32.cairo
 │   │   │   └── reduce_sum_u32.cairo
 │   │   ├── reduce_sum.cairo
@@ -46,7 +60,11 @@ src
 │   │   │   ├── relu
 │   │   │   │   ├── relu_i32.cairo
 │   │   │   │   └── relu_u32.cairo
-│   │   │   └── relu.cairo
+│   │   │   ├── relu.cairo
+│   │   │   ├── softmax
+│   │   │   │   ├── softmax_i32.cairo
+│   │   │   │   └── softmax_u32.cairo
+│   │   │   └── softmax.cairo
 │   │   ├── functional.cairo
 │   │   ├── nn_i32.cairo
 │   │   └── nn_u32.cairo
@@ -54,6 +72,7 @@ src
 │   ├── tensor
 │   │   ├── core.cairo
 │   │   ├── helpers.cairo
+│   │   ├── tensor_fp.cairo
 │   │   ├── tensor_i32.cairo
 │   │   └── tensor_u32.cairo
 │   └── tensor.cairo
@@ -61,6 +80,7 @@ src
 ├── performance
 │   ├── functional
 │   │   ├── quantization
+│   │   │   ├── quant_fp.cairo
 │   │   │   ├── quant_i32.cairo
 │   │   │   └── quant_u32.cairo
 │   │   └── quantization.cairo
@@ -75,13 +95,16 @@ src
 │   │   ├── linalg.cairo
 │   │   ├── math
 │   │   │   ├── argmax_test.cairo
+│   │   │   ├── exp_test.cairo
+│   │   │   ├── fixed_point_test.cairo
 │   │   │   ├── max_test.cairo
 │   │   │   ├── min_test.cairo
 │   │   │   ├── reduce_sum_test.cairo
 │   │   │   └── signed_integer_test.cairo
 │   │   ├── math.cairo
 │   │   ├── nn
-│   │   │   └── relu_test.cairo
+│   │   │   ├── relu_test.cairo
+│   │   │   └── softmax_test.cairo
 │   │   ├── nn.cairo
 │   │   ├── tensor
 │   │   │   ├── helpers.cairo

--- a/docs/readme/onnx_cairo_runtime/compatibility.md
+++ b/docs/readme/onnx_cairo_runtime/compatibility.md
@@ -16,7 +16,7 @@ You can see below the list of current supported ONNX Operators:
 |  Argmax   | :white_check_mark: |
 | ReduceSum | :white_check_mark: |
 |   ReLU    | :white_check_mark: |
-|  Softmax  | :hourglass: |
+|  Softmax  | :white_check_mark: |
 
 Performance optimizations:
 

--- a/src/operators/math.cairo
+++ b/src/operators/math.cairo
@@ -4,3 +4,4 @@ mod max;
 mod reduce_sum;
 mod argmax;
 mod fixed_point;
+mod exp;

--- a/src/operators/math/argmax/argmax_fp.cairo
+++ b/src/operators/math/argmax/argmax_fp.cairo
@@ -33,7 +33,7 @@ fn argmax(self: @Tensor<FixedType>, axis: usize) -> Tensor<usize> {
 
     let mut output_data = ArrayTrait::new();
 
-    let output_shape = reduce_output_shape(*self.shape, axis);
+    let output_shape = reduce_output_shape(*self.shape, axis, false);
     let output_data_len = len_from_shape(output_shape);
 
     let mut index: usize = 0;

--- a/src/operators/math/argmax/argmax_i32.cairo
+++ b/src/operators/math/argmax/argmax_i32.cairo
@@ -32,7 +32,7 @@ fn argmax(self: @Tensor<i32>, axis: usize) -> Tensor<usize> {
 
     let mut output_data = ArrayTrait::new();
 
-    let output_shape = reduce_output_shape(*self.shape, axis);
+    let output_shape = reduce_output_shape(*self.shape, axis, false);
     let output_data_len = len_from_shape(output_shape);
 
     let mut index: usize = 0;

--- a/src/operators/math/argmax/argmax_u32.cairo
+++ b/src/operators/math/argmax/argmax_u32.cairo
@@ -30,7 +30,7 @@ fn argmax(self: @Tensor<u32>, axis: usize) -> Tensor<usize> {
 
     let mut output_data = ArrayTrait::new();
 
-    let output_shape = reduce_output_shape(*self.shape, axis);
+    let output_shape = reduce_output_shape(*self.shape, axis, false);
     let output_data_len = len_from_shape(output_shape);
 
     let mut index: usize = 0;

--- a/src/operators/math/exp.cairo
+++ b/src/operators/math/exp.cairo
@@ -1,0 +1,3 @@
+mod exp_u32;
+mod exp_i32;
+mod exp_fp;

--- a/src/operators/math/exp/exp_fp.cairo
+++ b/src/operators/math/exp/exp_fp.cairo
@@ -1,0 +1,48 @@
+use array::ArrayTrait;
+use array::SpanTrait;
+use option::OptionTrait;
+use traits::Into;
+
+use onnx_cairo::operators::math::fixed_point::types::Fixed;
+use onnx_cairo::operators::math::fixed_point::types::FixedType;
+use onnx_cairo::operators::tensor::helpers::check_shape;
+use onnx_cairo::operators::tensor::helpers::check_compatibility;
+use onnx_cairo::operators::tensor::helpers::broadcast_index_mapping;
+use onnx_cairo::operators::tensor::core::Tensor;
+use onnx_cairo::operators::tensor::core::TensorTrait;
+use onnx_cairo::operators::tensor::core::ravel_index;
+use onnx_cairo::operators::tensor::core::unravel_index;
+use onnx_cairo::operators::tensor::tensor_fp;
+use onnx_cairo::utils::check_gas;
+
+
+/// Calculates the exponential function (e^x) for each element in a tensor of FixedType values.
+///
+/// # Arguments
+///
+/// * `self` - A tensor of FixedType values representing the input tensor.
+///
+/// # Panics
+///
+/// * If gas limit is reached during computation.
+///
+/// # Returns
+///
+/// * A tensor of fixed point numbers representing the result 
+fn exp(self: @Tensor<FixedType>) -> Tensor<FixedType> {
+    let mut result = ArrayTrait::new();
+    let mut data = *self.data;
+
+    loop {
+        check_gas();
+
+        let ele = *data.pop_front().unwrap();
+        result.append(Fixed::exp(ele));
+
+        if (data.len() == 0) {
+            break ();
+        };
+    };
+
+    return TensorTrait::<FixedType>::new(*self.shape, result.span());
+}

--- a/src/operators/math/exp/exp_i32.cairo
+++ b/src/operators/math/exp/exp_i32.cairo
@@ -1,0 +1,58 @@
+use array::ArrayTrait;
+use array::SpanTrait;
+use option::OptionTrait;
+use traits::Into;
+
+use onnx_cairo::operators::math::fixed_point::types::Fixed;
+use onnx_cairo::operators::math::fixed_point::types::FixedType;
+use onnx_cairo::operators::tensor::helpers::check_shape;
+use onnx_cairo::operators::tensor::helpers::check_compatibility;
+use onnx_cairo::operators::tensor::helpers::broadcast_index_mapping;
+use onnx_cairo::operators::tensor::core::Tensor;
+use onnx_cairo::operators::tensor::core::TensorTrait;
+use onnx_cairo::operators::tensor::core::ravel_index;
+use onnx_cairo::operators::tensor::core::unravel_index;
+use onnx_cairo::operators::tensor::tensor_fp;
+use onnx_cairo::operators::math::signed_integer::integer_trait::IntegerTrait;
+use onnx_cairo::operators::math::signed_integer::i32::i32;
+use onnx_cairo::operators::tensor::tensor_i32;
+use onnx_cairo::utils::check_gas;
+
+
+/// Calculates the exponential function (e^x) for each element in a tensor of i32 values.
+///
+/// # Arguments
+///
+/// * `self` - A tensor of i32 values representing the input tensor.
+///
+/// # Panics
+///
+/// * If gas limit is reached during computation.
+///
+/// # Returns
+///
+/// * A tensor of fixed point numbers representing the result 
+fn exp(self: @Tensor<i32>) -> Tensor<FixedType> {
+    let mut result = ArrayTrait::new();
+    let mut data = *self.data;
+
+    loop {
+        check_gas();
+
+        let ele = *data.pop_front().unwrap();
+
+        if ele.sign == true {
+            let ele = Fixed::from_unscaled_felt((ele.mag).into() * -1);
+            result.append(Fixed::exp(ele))
+        } else {
+            let ele = Fixed::from_unscaled_felt((ele.mag).into());
+            result.append(Fixed::exp(ele))
+        }
+
+        if (data.len() == 0) {
+            break ();
+        };
+    };
+
+    return TensorTrait::<FixedType>::new(*self.shape, result.span());
+}

--- a/src/operators/math/exp/exp_u32.cairo
+++ b/src/operators/math/exp/exp_u32.cairo
@@ -1,0 +1,50 @@
+use array::ArrayTrait;
+use array::SpanTrait;
+use option::OptionTrait;
+use traits::Into;
+
+use onnx_cairo::operators::math::fixed_point::types::Fixed;
+use onnx_cairo::operators::math::fixed_point::types::FixedType;
+use onnx_cairo::operators::tensor::helpers::check_shape;
+use onnx_cairo::operators::tensor::helpers::check_compatibility;
+use onnx_cairo::operators::tensor::helpers::broadcast_index_mapping;
+use onnx_cairo::operators::tensor::core::Tensor;
+use onnx_cairo::operators::tensor::core::TensorTrait;
+use onnx_cairo::operators::tensor::core::ravel_index;
+use onnx_cairo::operators::tensor::core::unravel_index;
+use onnx_cairo::operators::tensor::tensor_fp;
+use onnx_cairo::utils::check_gas;
+
+
+/// Calculates the exponential function (e^x) for each element in a tensor of u32 values.
+///
+/// # Arguments
+///
+/// * `self` - A tensor of u32 values representing the input tensor.
+///
+/// # Panics
+///
+/// * If gas limit is reached during computation.
+///
+/// # Returns
+///
+/// * A tensor of fixed point numbers representing the result 
+/// of applying the exponential function to each element in the input tensor.
+fn exp(self: @Tensor<u32>) -> Tensor<FixedType> {
+    let mut result = ArrayTrait::new();
+    let mut data = *self.data;
+
+    loop {
+        check_gas();
+
+        let ele = Fixed::from_unscaled_felt((*data.pop_front().unwrap()).into());
+
+        result.append(Fixed::exp(ele));
+
+        if (data.len() == 0) {
+            break ();
+        };
+    };
+
+    return TensorTrait::<FixedType>::new(*self.shape, result.span());
+}

--- a/src/operators/math/fixed_point/core.cairo
+++ b/src/operators/math/fixed_point/core.cairo
@@ -26,7 +26,7 @@ use onnx_cairo::operators::math::fixed_point::types::FixedAdd;
 use onnx_cairo::operators::math::fixed_point::types::FixedDiv;
 use onnx_cairo::operators::math::fixed_point::types::FixedMul;
 use onnx_cairo::operators::math::fixed_point::types::FixedNeg;
-
+use onnx_cairo::utils::check_gas;
 
 //! PUBLIC
 
@@ -54,6 +54,7 @@ fn abs(a: FixedType) -> FixedType {
 ///
 /// * The sum of the input fixed point numbers.
 fn add(a: FixedType, b: FixedType) -> FixedType {
+    check_gas();
     return Fixed::from_felt(a.into() + b.into());
 }
 
@@ -89,17 +90,18 @@ fn ceil(a: FixedType) -> FixedType {
 ///
 /// * The result of the division of the input fixed point numbers.
 fn div(a: FixedType, b: FixedType) -> FixedType {
-        let res_sign = a.sign ^ b.sign;
+    check_gas();
+    let res_sign = a.sign ^ b.sign;
 
-        // Invert b to preserve precision as much as possible
-        // TODO: replace if / when there is a felt div_rem supported
-        let (a_high, a_low) = integer::u128_wide_mul(a.mag, ONE_u128);
-        let b_inv = MAX_u128 / b.mag;
-        let res_u128 = a_low / b.mag + a_high * b_inv;
+    // Invert b to preserve precision as much as possible
+    // TODO: replace if / when there is a felt div_rem supported
+    let (a_high, a_low) = integer::u128_wide_mul(a.mag, ONE_u128);
+    let b_inv = MAX_u128 / b.mag;
+    let res_u128 = a_low / b.mag + a_high * b_inv;
 
-        // Re-apply sign
-        return FixedType { mag: res_u128, sign: res_sign };
-    }
+    // Re-apply sign
+    return FixedType { mag: res_u128, sign: res_sign };
+}
 
 /// Checks whether two fixed point numbers are equal.
 ///
@@ -357,12 +359,14 @@ fn lt(a: FixedType, b: FixedType) -> bool {
 ///
 /// * A FixedType value representing the product of the two input numbers.
 fn mul(a: FixedType, b: FixedType) -> FixedType {
+    check_gas();
+
     let res_sign = a.sign ^ b.sign;
 
     // Use u128 to multiply and shift back down
     // TODO: replace if / when there is a felt div_rem supported
     let (high, low) = integer::u128_wide_mul(a.mag, b.mag);
-    let res_u128 = high  + (low / ONE_u128);
+    let res_u128 = high + (low / ONE_u128);
 
     // Re-apply sign
     return FixedType { mag: res_u128, sign: res_sign };
@@ -468,6 +472,7 @@ fn sqrt(a: FixedType) -> FixedType {
 ///
 /// * A fixed point number representing the result of the subtraction.
 fn sub(a: FixedType, b: FixedType) -> FixedType {
+    check_gas();
     return Fixed::from_felt(a.into() - b.into());
 }
 

--- a/src/operators/math/fixed_point/core.cairo
+++ b/src/operators/math/fixed_point/core.cairo
@@ -89,17 +89,17 @@ fn ceil(a: FixedType) -> FixedType {
 ///
 /// * The result of the division of the input fixed point numbers.
 fn div(a: FixedType, b: FixedType) -> FixedType {
-    let res_sign = a.sign ^ b.sign;
-    let (a_high, a_low) = integer::u128_wide_mul(a.mag, ONE_u128);
-    let a_u256 = u256 { low: a_low, high: a_high };
-    let b_u256 = u256 { low: b.mag, high: 0_u128 };
-    let res_u256 = a_u256 / b_u256;
+        let res_sign = a.sign ^ b.sign;
 
-    assert(res_u256.high == 0_u128, 'result overflow');
+        // Invert b to preserve precision as much as possible
+        // TODO: replace if / when there is a felt div_rem supported
+        let (a_high, a_low) = integer::u128_wide_mul(a.mag, ONE_u128);
+        let b_inv = MAX_u128 / b.mag;
+        let res_u128 = a_low / b.mag + a_high * b_inv;
 
-    // Re-apply sign
-    return Fixed::new(res_u256.low, res_sign);
-}
+        // Re-apply sign
+        return FixedType { mag: res_u128, sign: res_sign };
+    }
 
 /// Checks whether two fixed point numbers are equal.
 ///

--- a/src/operators/math/reduce_sum/reduce_sum_fp.cairo
+++ b/src/operators/math/reduce_sum/reduce_sum_fp.cairo
@@ -19,6 +19,7 @@ use onnx_cairo::utils::check_gas;
 /// # Arguments
 /// * `self` - The input tensor.
 /// * `axis` - The axis along which to sum the elements.
+/// * `keepdims` - If true, retains reduced dimensions with length 1.
 ///
 /// # Panics
 /// * Panics if axis is not in the range of the input tensor's dimensions.

--- a/src/operators/math/reduce_sum/reduce_sum_fp.cairo
+++ b/src/operators/math/reduce_sum/reduce_sum_fp.cairo
@@ -26,11 +26,11 @@ use onnx_cairo::utils::check_gas;
 ///
 /// # Returns
 /// * A `Tensor<FixedType>` instance representing the result of the reduction.
-fn reduce_sum(self: @Tensor<FixedType>, axis: usize) -> Tensor<FixedType> {
+fn reduce_sum(self: @Tensor<FixedType>, axis: usize, keepdims: bool) -> Tensor<FixedType> {
     assert(axis <= (*self.shape).len(), 'axis out of dimensions');
     let mut output_data = ArrayTrait::new();
 
-    let output_shape = reduce_output_shape(*self.shape, axis);
+    let output_shape = reduce_output_shape(*self.shape, axis, false);
     let output_data_len = len_from_shape(output_shape);
 
     let mut index: usize = 0;
@@ -48,8 +48,14 @@ fn reduce_sum(self: @Tensor<FixedType>, axis: usize) -> Tensor<FixedType> {
         };
     };
 
-    return TensorTrait::<FixedType>::new(output_shape, output_data.span());
+    if keepdims {
+        let output_shape = reduce_output_shape(*self.shape, axis, true);
+        return TensorTrait::<FixedType>::new(output_shape, output_data.span());
+    } else {
+        return TensorTrait::<FixedType>::new(output_shape, output_data.span());
+    }
 }
+
 
 /// Helper function that accumulates the sum of elements along a specific axis.
 ///
@@ -63,6 +69,8 @@ fn reduce_sum(self: @Tensor<FixedType>, axis: usize) -> Tensor<FixedType> {
 ///
 /// # Returns
 /// * An FixedType value representing the accumulated sum along the specified axis.
+use debug::print_felt252;
+use traits::Into;
 fn accumulate_sum(
     input: @Tensor<FixedType>, output_indices: Span<usize>, axis: usize
 ) -> FixedType {
@@ -80,7 +88,6 @@ fn accumulate_sum(
         let input_indices = combine_indices(output_indices, axis_index, axis);
         let input_index = ravel_index(*input.shape, input_indices);
         let ele = *(*input.data).at(input_index);
-
         acc += ele;
         axis_index += 1;
     };

--- a/src/operators/math/reduce_sum/reduce_sum_i32.cairo
+++ b/src/operators/math/reduce_sum/reduce_sum_i32.cairo
@@ -19,6 +19,7 @@ use onnx_cairo::utils::check_gas;
 /// # Arguments
 /// * `self` - The input tensor.
 /// * `axis` - The axis along which to sum the elements.
+/// * `keepdims` - If true, retains reduced dimensions with length 1.
 ///
 /// # Panics
 /// * Panics if axis is not in the range of the input tensor's dimensions.

--- a/src/operators/math/reduce_sum/reduce_sum_i32.cairo
+++ b/src/operators/math/reduce_sum/reduce_sum_i32.cairo
@@ -26,11 +26,11 @@ use onnx_cairo::utils::check_gas;
 ///
 /// # Returns
 /// * A `Tensor<i32>` instance representing the result of the reduction.
-fn reduce_sum(self: @Tensor<i32>, axis: usize) -> Tensor<i32> {
+fn reduce_sum(self: @Tensor<i32>, axis: usize, keepdims: bool) -> Tensor<i32> {
     assert(axis <= (*self.shape).len(), 'axis out of dimensions');
     let mut output_data = ArrayTrait::new();
 
-    let output_shape = reduce_output_shape(*self.shape, axis);
+    let output_shape = reduce_output_shape(*self.shape, axis, false);
     let output_data_len = len_from_shape(output_shape);
 
     let mut index: usize = 0;

--- a/src/operators/math/reduce_sum/reduce_sum_u32.cairo
+++ b/src/operators/math/reduce_sum/reduce_sum_u32.cairo
@@ -24,11 +24,11 @@ use onnx_cairo::utils::check_gas;
 ///
 /// # Returns
 /// * A `Tensor<u32>` instance representing the result of the reduction.
-fn reduce_sum(self: @Tensor<u32>, axis: usize) -> Tensor<u32> {
+fn reduce_sum(self: @Tensor<u32>, axis: usize, keepdims: bool) -> Tensor<u32> {
     assert(axis <= (*self.shape).len(), 'axis out of dimensions');
     let mut output_data = ArrayTrait::new();
 
-    let output_shape = reduce_output_shape(*self.shape, axis);
+    let output_shape = reduce_output_shape(*self.shape, axis, false);
     let output_data_len = len_from_shape(output_shape);
 
     let mut index: usize = 0;

--- a/src/operators/math/reduce_sum/reduce_sum_u32.cairo
+++ b/src/operators/math/reduce_sum/reduce_sum_u32.cairo
@@ -17,6 +17,7 @@ use onnx_cairo::utils::check_gas;
 /// # Arguments
 /// * `self` - The input tensor.
 /// * `axis` - The axis along which to sum the elements.
+/// * `keepdims` - If true, retains reduced dimensions with length 1.
 ///
 /// # Panics
 /// * Panics if axis is not in the range of the input tensor's dimensions.

--- a/src/operators/math/signed_integer/i128.cairo
+++ b/src/operators/math/signed_integer/i128.cairo
@@ -1,4 +1,5 @@
 use onnx_cairo::operators::math::signed_integer::integer_trait::IntegerTrait;
+use onnx_cairo::utils::check_gas;
 
 // ====================== INT 128 ======================
 
@@ -316,6 +317,7 @@ fn i128_rem(a: i128, b: i128) -> i128 {
 // # Returns
 // * `(i128, i128)` - A tuple containing the quotient and the remainder of dividing `a` by `b`.
 fn i128_div_rem(a: i128, b: i128) -> (i128, i128) {
+    check_gas();
     let quotient = i128_div(a, b);
     let remainder = i128_rem(a, b);
 

--- a/src/operators/math/signed_integer/i16.cairo
+++ b/src/operators/math/signed_integer/i16.cairo
@@ -1,4 +1,5 @@
 use onnx_cairo::operators::math::signed_integer::integer_trait::IntegerTrait;
+use onnx_cairo::utils::check_gas;
 
 // ====================== INT 16 ======================
 
@@ -316,6 +317,7 @@ fn i16_rem(a: i16, b: i16) -> i16 {
 // # Returns
 // * `(i16, i16)` - A tuple containing the quotient and the remainder of dividing `a` by `b`.
 fn i16_div_rem(a: i16, b: i16) -> (i16, i16) {
+    check_gas();
     let quotient = i16_div(a, b);
     let remainder = i16_rem(a, b);
 

--- a/src/operators/math/signed_integer/i32.cairo
+++ b/src/operators/math/signed_integer/i32.cairo
@@ -1,4 +1,5 @@
 use onnx_cairo::operators::math::signed_integer::integer_trait::IntegerTrait;
+use onnx_cairo::utils::check_gas;
 
 // ====================== INT 32 ======================
 
@@ -316,6 +317,7 @@ fn i32_rem(a: i32, b: i32) -> i32 {
 // # Returns
 // * `(i32, i32)` - A tuple containing the quotient and the remainder of dividing `a` by `b`.
 fn i32_div_rem(a: i32, b: i32) -> (i32, i32) {
+    check_gas();
     let quotient = i32_div(a, b);
     let remainder = i32_rem(a, b);
 

--- a/src/operators/math/signed_integer/i64.cairo
+++ b/src/operators/math/signed_integer/i64.cairo
@@ -1,4 +1,5 @@
 use onnx_cairo::operators::math::signed_integer::integer_trait::IntegerTrait;
+use onnx_cairo::utils::check_gas;
 
 // ====================== INT 64 ======================
 
@@ -316,6 +317,7 @@ fn i64_rem(a: i64, b: i64) -> i64 {
 // # Returns
 // * `(i64, i64)` - A tuple containing the quotient and the remainder of dividing `a` by `b`.
 fn i64_div_rem(a: i64, b: i64) -> (i64, i64) {
+    check_gas();
     let quotient = i64_div(a, b);
     let remainder = i64_rem(a, b);
 

--- a/src/operators/math/signed_integer/i8.cairo
+++ b/src/operators/math/signed_integer/i8.cairo
@@ -1,4 +1,5 @@
 use onnx_cairo::operators::math::signed_integer::integer_trait::IntegerTrait;
+use onnx_cairo::utils::check_gas;
 
 // ====================== INT 8 ======================
 
@@ -316,6 +317,7 @@ fn i8_rem(a: i8, b: i8) -> i8 {
 // # Returns
 // * `(i8, i8)` - A tuple containing the quotient and the remainder of dividing `a` by `b`.
 fn i8_div_rem(a: i8, b: i8) -> (i8, i8) {
+    check_gas();
     let quotient = i8_div(a, b);
     let remainder = i8_rem(a, b);
 

--- a/src/operators/nn/functional.cairo
+++ b/src/operators/nn/functional.cairo
@@ -1,1 +1,2 @@
 mod relu;
+mod softmax;

--- a/src/operators/nn/functional/softmax.cairo
+++ b/src/operators/nn/functional/softmax.cairo
@@ -1,0 +1,2 @@
+mod softmax_u32;
+mod softmax_i32;

--- a/src/operators/nn/functional/softmax/softmax_i32.cairo
+++ b/src/operators/nn/functional/softmax/softmax_i32.cairo
@@ -9,6 +9,12 @@ use onnx_cairo::operators::tensor::core::Tensor;
 use onnx_cairo::operators::tensor::core::TensorTrait;
 use onnx_cairo::operators::tensor::tensor_i32;
 use onnx_cairo::operators::tensor::tensor_fp;
+use onnx_cairo::operators::tensor::helpers::len_from_shape;
+use onnx_cairo::operators::tensor::helpers::broadcast_index_mapping;
+
+use onnx_cairo::operators::tensor::core::unravel_index;
+use onnx_cairo::operators::tensor::core::ravel_index;
+
 use onnx_cairo::operators::math::fixed_point::core::FixedType;
 use onnx_cairo::utils::check_gas;
 
@@ -25,8 +31,9 @@ use onnx_cairo::utils::check_gas;
 /// to the input tensor along the specified axis.
 fn softmax_i32(z: @Tensor<i32>, axis: usize) -> Tensor<FixedType> {
     let exp_tensor = z.exp();
-    let sum = exp_tensor.reduce_sum(axis);
+    let sum = exp_tensor.reduce_sum(axis, true);
     let softmax = exp_tensor / sum;
 
     return softmax;
 }
+

--- a/src/operators/nn/functional/softmax/softmax_i32.cairo
+++ b/src/operators/nn/functional/softmax/softmax_i32.cairo
@@ -1,0 +1,32 @@
+use array::ArrayTrait;
+use array::SpanTrait;
+use traits::Into;
+use option::OptionTrait;
+
+use onnx_cairo::operators::math::signed_integer::integer_trait::IntegerTrait;
+use onnx_cairo::operators::math::signed_integer::i32::i32;
+use onnx_cairo::operators::tensor::core::Tensor;
+use onnx_cairo::operators::tensor::core::TensorTrait;
+use onnx_cairo::operators::tensor::tensor_i32;
+use onnx_cairo::operators::tensor::tensor_fp;
+use onnx_cairo::operators::math::fixed_point::core::FixedType;
+use onnx_cairo::utils::check_gas;
+
+/// Calculates the softmax function for a tensor of i32 values along the specified axis.
+///
+/// # Arguments
+///
+/// * `z` - A tensor of i32 values representing the input tensor.
+/// * `axis` - The axis along which to compute the softmax function.
+///
+/// # Returns
+///
+/// * A tensor of fixed point numbers representing the result of applying the softmax function 
+/// to the input tensor along the specified axis.
+fn softmax_i32(z: @Tensor<i32>, axis: usize) -> Tensor<FixedType> {
+    let exp_tensor = z.exp();
+    let sum = exp_tensor.reduce_sum(axis);
+    let softmax = exp_tensor / sum;
+
+    return softmax;
+}

--- a/src/operators/nn/functional/softmax/softmax_u32.cairo
+++ b/src/operators/nn/functional/softmax/softmax_u32.cairo
@@ -23,7 +23,7 @@ use onnx_cairo::utils::check_gas;
 /// to the input tensor along the specified axis.
 fn softmax_u32(z: @Tensor<u32>, axis: usize) -> Tensor<FixedType> {
     let exp_tensor = z.exp();
-    let sum = exp_tensor.reduce_sum(axis);
+    let sum = exp_tensor.reduce_sum(axis, true);
     let softmax = exp_tensor / sum;
 
     return softmax;

--- a/src/operators/nn/functional/softmax/softmax_u32.cairo
+++ b/src/operators/nn/functional/softmax/softmax_u32.cairo
@@ -1,0 +1,30 @@
+use array::ArrayTrait;
+use array::SpanTrait;
+use traits::Into;
+use option::OptionTrait;
+
+use onnx_cairo::operators::tensor::core::Tensor;
+use onnx_cairo::operators::tensor::core::TensorTrait;
+use onnx_cairo::operators::tensor::tensor_u32;
+use onnx_cairo::operators::tensor::tensor_fp;
+use onnx_cairo::operators::math::fixed_point::core::FixedType;
+use onnx_cairo::utils::check_gas;
+
+/// Calculates the softmax function for a tensor of u32 values along the specified axis.
+///
+/// # Arguments
+///
+/// * `z` - A tensor of u32 values representing the input tensor.
+/// * `axis` - The axis along which to compute the softmax function.
+///
+/// # Returns
+///
+/// * A tensor of fixed point numbers representing the result of applying the softmax function 
+/// to the input tensor along the specified axis.
+fn softmax_u32(z: @Tensor<u32>, axis: usize) -> Tensor<FixedType> {
+    let exp_tensor = z.exp();
+    let sum = exp_tensor.reduce_sum(axis);
+    let softmax = exp_tensor / sum;
+
+    return softmax;
+}

--- a/src/operators/nn/nn_i32.cairo
+++ b/src/operators/nn/nn_i32.cairo
@@ -2,13 +2,15 @@ mod nn {
     use onnx_cairo::operators::tensor::core::Tensor;
     use onnx_cairo::operators::math::signed_integer::i32::i32;
     use onnx_cairo::operators::nn::functional::relu::relu_i32::relu_i32;
+    use onnx_cairo::operators::nn::functional::softmax::softmax_i32::softmax_i32;
+    use onnx_cairo::operators::math::fixed_point::core::FixedType;
 
     /// Applies the rectified linear unit (ReLU) activation function element-wise to a given i32 tensor.
     ///
     /// The ReLU function is defined as f(x) = max(0, x), where x is the input element.
     ///
     /// # Arguments
-    /// * `z` - A reference to an i32 tensor to which the ReLU function will be applied.
+    /// * `tensor` - A reference to an i32 tensor to which the ReLU function will be applied.
     ///
     /// # Panics
     /// * Panics if gas limit is exceeded during execution.
@@ -18,5 +20,20 @@ mod nn {
     ///   applied element-wise.
     fn relu(tensor: @Tensor<i32>) -> Tensor<i32> {
         relu_i32(tensor)
+    }
+
+    /// Calculates the softmax function for a tensor of i32 values along the specified axis.
+    ///
+    /// # Arguments
+    ///
+    /// * `tensor` - A tensor of i32 values representing the input tensor.
+    /// * `axis` - The axis along which to compute the softmax function.
+    ///
+    /// # Returns
+    ///
+    /// * A tensor of fixed point numbers representing the result of applying the softmax function 
+    /// to the input tensor along the specified axis.
+    fn softmax(tensor: @Tensor<i32>, axis: usize) -> Tensor<FixedType> {
+        softmax_i32(tensor, axis)
     }
 }

--- a/src/operators/nn/nn_u32.cairo
+++ b/src/operators/nn/nn_u32.cairo
@@ -1,6 +1,8 @@
 mod nn {
     use onnx_cairo::operators::tensor::core::Tensor;
     use onnx_cairo::operators::nn::functional::relu::relu_u32::relu_u32;
+    use onnx_cairo::operators::nn::functional::softmax::softmax_u32::softmax_u32;
+    use onnx_cairo::operators::math::fixed_point::core::FixedType;
 
     /// Applies the rectified linear unit (ReLU) activation function element-wise to a given u32 tensor.
     ///
@@ -17,5 +19,20 @@ mod nn {
     ///   applied element-wise.
     fn relu(tensor: @Tensor<u32>) -> Tensor<u32> {
         relu_u32(tensor)
+    }
+
+    /// Calculates the softmax function for a tensor of u32 values along the specified axis.
+    ///
+    /// # Arguments
+    ///
+    /// * `tensor` - A tensor of u32 values representing the input tensor.
+    /// * `axis` - The axis along which to compute the softmax function.
+    ///
+    /// # Returns
+    ///
+    /// * A tensor of fixed point numbers representing the result of applying the softmax function 
+    /// to the input tensor along the specified axis.
+    fn softmax(tensor: @Tensor<u32>, axis: usize) -> Tensor<FixedType> {
+        softmax_u32(tensor, axis)
     }
 }

--- a/src/operators/tensor/core.cairo
+++ b/src/operators/tensor/core.cairo
@@ -5,6 +5,7 @@ use option::OptionTrait;
 use onnx_cairo::utils::check_gas;
 use onnx_cairo::operators::tensor::helpers::len_from_shape;
 use onnx_cairo::operators::tensor::helpers::check_shape;
+use onnx_cairo::operators::math::fixed_point::types::FixedType;
 
 /// A generic Tensor struct representing n-dimensional arrays.
 ///
@@ -34,6 +35,7 @@ impl TensorDrop<T> of Drop<Tensor<T>>;
 /// * `reduce_sum` - Reduces the tensor by summing along the specified axis.
 /// * `argmax` - Returns the index of the maximum value along the specified axis.
 /// * `matmul` - Performs matrix multiplication.
+/// * `exp` - Calculates the exponential function (e^x) for each element in a tensor.
 trait TensorTrait<T> {
     fn new(shape: Span<usize>, data: Span<T>) -> Tensor<T>;
     fn at(self: @Tensor<T>, indices: Span<usize>) -> T;
@@ -47,6 +49,7 @@ trait TensorTrait<T> {
     fn reduce_sum(self: @Tensor<T>, axis: usize) -> Tensor<T>;
     fn argmax(self: @Tensor<T>, axis: usize) -> Tensor<usize>;
     fn matmul(self: @Tensor<T>, other: @Tensor<T>) -> Tensor<T>;
+    fn exp(self: @Tensor<T>) -> Tensor<FixedType>;
 }
 
 /// Constructs a new tensor with the given shape and data array after checking compatibility.

--- a/src/operators/tensor/core.cairo
+++ b/src/operators/tensor/core.cairo
@@ -46,7 +46,7 @@ trait TensorTrait<T> {
     fn unravel_index(self: @Tensor<T>, index: usize) -> Span<usize>;
     fn reshape(self: @Tensor<T>, target_shape: Span<usize>) -> Tensor<T>;
     fn transpose(self: @Tensor<T>, axes: Span<usize>) -> Tensor<T>;
-    fn reduce_sum(self: @Tensor<T>, axis: usize) -> Tensor<T>;
+    fn reduce_sum(self: @Tensor<T>, axis: usize, keepdims: bool) -> Tensor<T>;
     fn argmax(self: @Tensor<T>, axis: usize) -> Tensor<usize>;
     fn matmul(self: @Tensor<T>, other: @Tensor<T>) -> Tensor<T>;
     fn exp(self: @Tensor<T>) -> Tensor<FixedType>;

--- a/src/operators/tensor/helpers.cairo
+++ b/src/operators/tensor/helpers.cairo
@@ -120,8 +120,8 @@ fn broadcast_index_mapping(mut shape: Span<usize>, mut indices: Span<usize>) -> 
 ///
 /// # Returns
 /// * A Span of usize representing the output shape after reduction.
-fn reduce_output_shape(input_shape: Span<usize>, axis: usize, keepdims: bool) -> Span<usize> {
-    assert(axis <= input_shape.len(), 'axis out of dimensions');
+fn reduce_output_shape(mut input_shape: Span<usize>, axis: usize, keepdims: bool) -> Span<usize> {
+    assert(axis < input_shape.len(), 'axis out of dimensions');
 
     let mut output_shape = ArrayTrait::new();
     let mut n: usize = 0;
@@ -129,16 +129,18 @@ fn reduce_output_shape(input_shape: Span<usize>, axis: usize, keepdims: bool) ->
     loop {
         check_gas();
 
-        if n == input_shape.len() {
+        if input_shape.len() == 0 {
             break ();
         }
 
+        let current_dim = *input_shape.pop_front().unwrap();
+
         if n == axis {
             if keepdims {
-                output_shape.append(1); // Retain the reduced dimension with length 1
+                output_shape.append(1);
             }
         } else {
-            output_shape.append(*input_shape.at(n));
+            output_shape.append(current_dim);
         }
 
         n += 1;
@@ -146,6 +148,7 @@ fn reduce_output_shape(input_shape: Span<usize>, axis: usize, keepdims: bool) ->
 
     return output_shape.span();
 }
+
 
 /// Helper function that computes the output shape of a tensor after applying the axes permutation.
 ///
@@ -287,7 +290,7 @@ fn broadcast_shape(mut shape1: Span<usize>, mut shape2: Span<usize>) -> Span<usi
         };
 
         let broadcasted_dim = u32_max(dim1, dim2);
-        temp_result.append(broadcasted_dim); 
+        temp_result.append(broadcasted_dim);
 
         if shape1.len() == 0 & shape2.len() == 0 {
             break ();

--- a/src/operators/tensor/tensor_fp.cairo
+++ b/src/operators/tensor/tensor_fp.cairo
@@ -8,6 +8,7 @@ use onnx_cairo::operators::math::fixed_point::types::Fixed;
 use onnx_cairo::operators::math::fixed_point::types::FixedType;
 use onnx_cairo::operators::tensor::helpers::check_shape;
 use onnx_cairo::operators::tensor::helpers::check_compatibility;
+use onnx_cairo::operators::tensor::helpers::broadcast_shape;
 use onnx_cairo::operators::tensor::core::new_tensor;
 use onnx_cairo::operators::tensor::core::stride;
 use onnx_cairo::operators::tensor::core::Tensor;
@@ -334,28 +335,29 @@ fn FixedType_at_tensor(self: @Tensor<FixedType>, indices: Span<usize>) -> FixedT
 /// # Returns
 /// * A `Tensor<FixedType>` instance representing the result of the element-wise addition with broadcasting.
 fn FixedType_add_tensor(self: @Tensor<FixedType>, other: @Tensor<FixedType>) -> Tensor<FixedType> {
-    check_compatibility(*self.shape, *other.shape);
+    let broadcasted_shape = broadcast_shape(*self.shape, *other.shape);
     let mut result = ArrayTrait::new();
+
+    let num_elements = len_from_shape(broadcasted_shape);
 
     let mut n: usize = 0;
     loop {
         check_gas();
 
-        let indices_self = self.unravel_index(n);
-        let indices_other = other.unravel_index(n);
+        let indices_broadcasted = unravel_index(n, broadcasted_shape);
 
-        let i = broadcast_index_mapping(*self.shape, indices_self);
-        let j = broadcast_index_mapping(*other.shape, indices_other);
+        let indices_self = broadcast_index_mapping(*self.shape, indices_broadcasted);
+        let indices_other = broadcast_index_mapping(*other.shape, indices_broadcasted);
 
-        result.append(*(*self.data).at(i) + *(*other.data).at(j));
+        result.append(*(*self.data).at(indices_self) + *(*other.data).at(indices_other));
 
         n += 1;
-        if n == (*self.data).len() {
+        if n == num_elements {
             break ();
         };
     };
 
-    return TensorTrait::<FixedType>::new(*self.shape, result.span());
+    return TensorTrait::<FixedType>::new(broadcasted_shape, result.span());
 }
 
 /// Subtracts two `Tensor<FixedType>` instances element-wise with broadcasting.
@@ -371,28 +373,29 @@ fn FixedType_add_tensor(self: @Tensor<FixedType>, other: @Tensor<FixedType>) -> 
 /// # Returns
 /// * A `Tensor<FixedType>` instance representing the result of the element-wise subtraction with broadcasting.
 fn FixedType_sub_tensor(self: @Tensor<FixedType>, other: @Tensor<FixedType>) -> Tensor<FixedType> {
-    check_compatibility(*self.shape, *other.shape);
+    let broadcasted_shape = broadcast_shape(*self.shape, *other.shape);
     let mut result = ArrayTrait::new();
+
+    let num_elements = len_from_shape(broadcasted_shape);
 
     let mut n: usize = 0;
     loop {
         check_gas();
 
-        let indices_self = self.unravel_index(n);
-        let indices_other = other.unravel_index(n);
+        let indices_broadcasted = unravel_index(n, broadcasted_shape);
 
-        let i = broadcast_index_mapping(*self.shape, indices_self);
-        let j = broadcast_index_mapping(*other.shape, indices_other);
+        let indices_self = broadcast_index_mapping(*self.shape, indices_broadcasted);
+        let indices_other = broadcast_index_mapping(*other.shape, indices_broadcasted);
 
-        result.append(*(*self.data).at(i) - *(*other.data).at(j));
+        result.append(*(*self.data).at(indices_self) - *(*other.data).at(indices_other));
 
         n += 1;
-        if n == (*self.data).len() {
+        if n == num_elements {
             break ();
         };
     };
 
-    return TensorTrait::<FixedType>::new(*self.shape, result.span());
+    return TensorTrait::<FixedType>::new(broadcasted_shape, result.span());
 }
 
 /// Multiplies two `Tensor<FixedType>` instances element-wise with broadcasting.
@@ -408,28 +411,29 @@ fn FixedType_sub_tensor(self: @Tensor<FixedType>, other: @Tensor<FixedType>) -> 
 /// # Returns
 /// * A `Tensor<FixedType>` instance representing the result of the element-wise multiplication with broadcasting.
 fn FixedType_mul_tensor(self: @Tensor<FixedType>, other: @Tensor<FixedType>) -> Tensor<FixedType> {
-    check_compatibility(*self.shape, *other.shape);
+    let broadcasted_shape = broadcast_shape(*self.shape, *other.shape);
     let mut result = ArrayTrait::new();
+
+    let num_elements = len_from_shape(broadcasted_shape);
 
     let mut n: usize = 0;
     loop {
         check_gas();
 
-        let indices_self = self.unravel_index(n);
-        let indices_other = other.unravel_index(n);
+        let indices_broadcasted = unravel_index(n, broadcasted_shape);
 
-        let i = broadcast_index_mapping(*self.shape, indices_self);
-        let j = broadcast_index_mapping(*other.shape, indices_other);
+        let indices_self = broadcast_index_mapping(*self.shape, indices_broadcasted);
+        let indices_other = broadcast_index_mapping(*other.shape, indices_broadcasted);
 
-        result.append(*(*self.data).at(i) * *(*other.data).at(j));
+        result.append(*(*self.data).at(indices_self) * *(*other.data).at(indices_other));
 
         n += 1;
-        if n == (*self.data).len() {
+        if n == num_elements {
             break ();
         };
     };
 
-    return TensorTrait::<FixedType>::new(*self.shape, result.span());
+    return TensorTrait::<FixedType>::new(broadcasted_shape, result.span());
 }
 
 /// Divides two `Tensor<FixedType>` instances element-wise with broadcasting.
@@ -445,28 +449,29 @@ fn FixedType_mul_tensor(self: @Tensor<FixedType>, other: @Tensor<FixedType>) -> 
 /// # Returns
 /// * A `Tensor<FixedType>` instance representing the result of the element-wise division with broadcasting.
 fn FixedType_div_tensor(self: @Tensor<FixedType>, other: @Tensor<FixedType>) -> Tensor<FixedType> {
-    check_compatibility(*self.shape, *other.shape);
+    let broadcasted_shape = broadcast_shape(*self.shape, *other.shape);
     let mut result = ArrayTrait::new();
+
+    let num_elements = len_from_shape(broadcasted_shape);
 
     let mut n: usize = 0;
     loop {
         check_gas();
 
-        let indices_self = self.unravel_index(n);
-        let indices_other = other.unravel_index(n);
+        let indices_broadcasted = unravel_index(n, broadcasted_shape);
 
-        let i = broadcast_index_mapping(*self.shape, indices_self);
-        let j = broadcast_index_mapping(*other.shape, indices_other);
+        let indices_self = broadcast_index_mapping(*self.shape, indices_broadcasted);
+        let indices_other = broadcast_index_mapping(*other.shape, indices_broadcasted);
 
-        result.append(*(*self.data).at(i) / *(*other.data).at(j));
+        result.append(*(*self.data).at(indices_self) / *(*other.data).at(indices_other));
 
         n += 1;
-        if n == (*self.data).len() {
+        if n == num_elements {
             break ();
         };
     };
 
-    return TensorTrait::<FixedType>::new(*self.shape, result.span());
+    return TensorTrait::<FixedType>::new(broadcasted_shape, result.span());
 }
 
 /// Reorders the axes of an FixedType tensor according to the given axes permutation.

--- a/src/operators/tensor/tensor_fp.cairo
+++ b/src/operators/tensor/tensor_fp.cairo
@@ -163,8 +163,8 @@ impl FixedTypeTensor of TensorTrait<FixedType> {
     ///
     /// # Returns
     /// * A new `Tensor<FixedType>` instance with the specified axis reduced by summing its elements.
-    fn reduce_sum(self: @Tensor<FixedType>, axis: usize) -> Tensor<FixedType> {
-        reduce_sum(self, axis)
+    fn reduce_sum(self: @Tensor<FixedType>, axis: usize, keepdims: bool) -> Tensor<FixedType> {
+        reduce_sum(self, axis, keepdims)
     }
 
     /// Computes the indices of the maximum values along the given axis of an FixedType tensor.

--- a/src/operators/tensor/tensor_fp.cairo
+++ b/src/operators/tensor/tensor_fp.cairo
@@ -27,6 +27,7 @@ use onnx_cairo::operators::math::max::max_fp::max_in_tensor;
 use onnx_cairo::operators::math::reduce_sum::reduce_sum_fp::reduce_sum;
 use onnx_cairo::operators::math::argmax::argmax_fp::argmax;
 use onnx_cairo::operators::linalg::matmul::matmul_fp::matmul;
+use onnx_cairo::operators::math::exp::exp_fp::exp;
 use onnx_cairo::utils::check_gas;
 
 impl FixedTypeTensor of TensorTrait<FixedType> {
@@ -221,6 +222,23 @@ impl FixedTypeTensor of TensorTrait<FixedType> {
     /// * A new `Tensor<FixedType>` resulting from the matrix multiplication.
     fn matmul(self: @Tensor<FixedType>, other: @Tensor<FixedType>) -> Tensor<FixedType> {
         matmul(self, other)
+    }
+
+    /// Calculates the exponential function (e^x) for each element in a tensor of FixedType values.
+    ///
+    /// # Arguments
+    ///
+    /// * `self` - A tensor of FixedType values representing the input tensor.
+    ///
+    /// # Panics
+    ///
+    /// * If gas limit is reached during computation.
+    ///
+    /// # Returns
+    ///
+    /// * A tensor of fixed point numbers representing the result 
+    fn exp(self: @Tensor<FixedType>) -> Tensor<FixedType> {
+        exp(self)
     }
 }
 

--- a/src/operators/tensor/tensor_i32.cairo
+++ b/src/operators/tensor/tensor_i32.cairo
@@ -6,6 +6,7 @@ use option::OptionTrait;
 
 use onnx_cairo::operators::math::signed_integer::integer_trait::IntegerTrait;
 use onnx_cairo::operators::math::signed_integer::i32::i32;
+use onnx_cairo::operators::math::fixed_point::types::FixedType;
 use onnx_cairo::operators::tensor::helpers::check_shape;
 use onnx_cairo::operators::tensor::helpers::check_compatibility;
 use onnx_cairo::operators::tensor::core::new_tensor;
@@ -27,6 +28,7 @@ use onnx_cairo::operators::math::max::max_i32::max_in_tensor;
 use onnx_cairo::operators::math::reduce_sum::reduce_sum_i32::reduce_sum;
 use onnx_cairo::operators::math::argmax::argmax_i32::argmax;
 use onnx_cairo::operators::linalg::matmul::matmul_i32::matmul;
+use onnx_cairo::operators::math::exp::exp_i32::exp;
 use onnx_cairo::utils::check_gas;
 
 impl i32Tensor of TensorTrait<i32> {
@@ -221,6 +223,23 @@ impl i32Tensor of TensorTrait<i32> {
     /// * A new `Tensor<i32>` resulting from the matrix multiplication.
     fn matmul(self: @Tensor<i32>, other: @Tensor<i32>) -> Tensor<i32> {
         matmul(self, other)
+    }
+
+    /// Calculates the exponential function (e^x) for each element in a tensor of i32 values.
+    ///
+    /// # Arguments
+    ///
+    /// * `self` - A tensor of i32 values representing the input tensor.
+    ///
+    /// # Panics
+    ///
+    /// * If gas limit is reached during computation.
+    ///
+    /// # Returns
+    ///
+    /// * A tensor of fixed point numbers representing the result 
+    fn exp(self: @Tensor<i32>) -> Tensor<FixedType> {
+        exp(self)
     }
 }
 

--- a/src/operators/tensor/tensor_i32.cairo
+++ b/src/operators/tensor/tensor_i32.cairo
@@ -164,8 +164,8 @@ impl i32Tensor of TensorTrait<i32> {
     ///
     /// # Returns
     /// * A new `Tensor<i32>` instance with the specified axis reduced by summing its elements.
-    fn reduce_sum(self: @Tensor<i32>, axis: usize) -> Tensor<i32> {
-        reduce_sum(self, axis)
+    fn reduce_sum(self: @Tensor<i32>, axis: usize, keepdims: bool) -> Tensor<i32> {
+        reduce_sum(self, axis, keepdims)
     }
 
     /// Computes the indices of the maximum values along the given axis of an i32 tensor.

--- a/src/operators/tensor/tensor_i32.cairo
+++ b/src/operators/tensor/tensor_i32.cairo
@@ -9,6 +9,7 @@ use onnx_cairo::operators::math::signed_integer::i32::i32;
 use onnx_cairo::operators::math::fixed_point::types::FixedType;
 use onnx_cairo::operators::tensor::helpers::check_shape;
 use onnx_cairo::operators::tensor::helpers::check_compatibility;
+use onnx_cairo::operators::tensor::helpers::broadcast_shape;
 use onnx_cairo::operators::tensor::core::new_tensor;
 use onnx_cairo::operators::tensor::core::stride;
 use onnx_cairo::operators::tensor::core::Tensor;
@@ -335,28 +336,29 @@ fn i32_at_tensor(self: @Tensor<i32>, indices: Span<usize>) -> i32 {
 /// # Returns
 /// * A `Tensor<i32>` instance representing the result of the element-wise addition with broadcasting.
 fn i32_add_tensor(self: @Tensor<i32>, other: @Tensor<i32>) -> Tensor<i32> {
-    check_compatibility(*self.shape, *other.shape);
+    let broadcasted_shape = broadcast_shape(*self.shape, *other.shape);
     let mut result = ArrayTrait::new();
+
+    let num_elements = len_from_shape(broadcasted_shape);
 
     let mut n: usize = 0;
     loop {
         check_gas();
 
-        let indices_self = self.unravel_index(n);
-        let indices_other = other.unravel_index(n);
+        let indices_broadcasted = unravel_index(n, broadcasted_shape);
 
-        let i = broadcast_index_mapping(*self.shape, indices_self);
-        let j = broadcast_index_mapping(*other.shape, indices_other);
+        let indices_self = broadcast_index_mapping(*self.shape, indices_broadcasted);
+        let indices_other = broadcast_index_mapping(*other.shape, indices_broadcasted);
 
-        result.append(*(*self.data).at(i) + *(*other.data).at(j));
+        result.append(*(*self.data).at(indices_self) + *(*other.data).at(indices_other));
 
         n += 1;
-        if n == (*self.data).len() {
+        if n == num_elements {
             break ();
         };
     };
 
-    return TensorTrait::<i32>::new(*self.shape, result.span());
+    return TensorTrait::<i32>::new(broadcasted_shape, result.span());
 }
 
 /// Subtracts two `Tensor<i32>` instances element-wise with broadcasting.
@@ -372,28 +374,29 @@ fn i32_add_tensor(self: @Tensor<i32>, other: @Tensor<i32>) -> Tensor<i32> {
 /// # Returns
 /// * A `Tensor<i32>` instance representing the result of the element-wise subtraction with broadcasting.
 fn i32_sub_tensor(self: @Tensor<i32>, other: @Tensor<i32>) -> Tensor<i32> {
-    check_compatibility(*self.shape, *other.shape);
+    let broadcasted_shape = broadcast_shape(*self.shape, *other.shape);
     let mut result = ArrayTrait::new();
+
+    let num_elements = len_from_shape(broadcasted_shape);
 
     let mut n: usize = 0;
     loop {
         check_gas();
 
-        let indices_self = self.unravel_index(n);
-        let indices_other = other.unravel_index(n);
+        let indices_broadcasted = unravel_index(n, broadcasted_shape);
 
-        let i = broadcast_index_mapping(*self.shape, indices_self);
-        let j = broadcast_index_mapping(*other.shape, indices_other);
+        let indices_self = broadcast_index_mapping(*self.shape, indices_broadcasted);
+        let indices_other = broadcast_index_mapping(*other.shape, indices_broadcasted);
 
-        result.append(*(*self.data).at(i) - *(*other.data).at(j));
+        result.append(*(*self.data).at(indices_self) - *(*other.data).at(indices_other));
 
         n += 1;
-        if n == (*self.data).len() {
+        if n == num_elements {
             break ();
         };
     };
 
-    return TensorTrait::<i32>::new(*self.shape, result.span());
+    return TensorTrait::<i32>::new(broadcasted_shape, result.span());
 }
 
 /// Multiplies two `Tensor<i32>` instances element-wise with broadcasting.
@@ -409,28 +412,29 @@ fn i32_sub_tensor(self: @Tensor<i32>, other: @Tensor<i32>) -> Tensor<i32> {
 /// # Returns
 /// * A `Tensor<i32>` instance representing the result of the element-wise multiplication with broadcasting.
 fn i32_mul_tensor(self: @Tensor<i32>, other: @Tensor<i32>) -> Tensor<i32> {
-    check_compatibility(*self.shape, *other.shape);
+    let broadcasted_shape = broadcast_shape(*self.shape, *other.shape);
     let mut result = ArrayTrait::new();
+
+    let num_elements = len_from_shape(broadcasted_shape);
 
     let mut n: usize = 0;
     loop {
         check_gas();
 
-        let indices_self = self.unravel_index(n);
-        let indices_other = other.unravel_index(n);
+        let indices_broadcasted = unravel_index(n, broadcasted_shape);
 
-        let i = broadcast_index_mapping(*self.shape, indices_self);
-        let j = broadcast_index_mapping(*other.shape, indices_other);
+        let indices_self = broadcast_index_mapping(*self.shape, indices_broadcasted);
+        let indices_other = broadcast_index_mapping(*other.shape, indices_broadcasted);
 
-        result.append(*(*self.data).at(i) * *(*other.data).at(j));
+        result.append(*(*self.data).at(indices_self) * *(*other.data).at(indices_other));
 
         n += 1;
-        if n == (*self.data).len() {
+        if n == num_elements {
             break ();
         };
     };
 
-    return TensorTrait::<i32>::new(*self.shape, result.span());
+    return TensorTrait::<i32>::new(broadcasted_shape, result.span());
 }
 
 /// Divides two `Tensor<i32>` instances element-wise with broadcasting.
@@ -446,28 +450,29 @@ fn i32_mul_tensor(self: @Tensor<i32>, other: @Tensor<i32>) -> Tensor<i32> {
 /// # Returns
 /// * A `Tensor<i32>` instance representing the result of the element-wise division with broadcasting.
 fn i32_div_tensor(self: @Tensor<i32>, other: @Tensor<i32>) -> Tensor<i32> {
-    check_compatibility(*self.shape, *other.shape);
+    let broadcasted_shape = broadcast_shape(*self.shape, *other.shape);
     let mut result = ArrayTrait::new();
+
+    let num_elements = len_from_shape(broadcasted_shape);
 
     let mut n: usize = 0;
     loop {
         check_gas();
 
-        let indices_self = self.unravel_index(n);
-        let indices_other = other.unravel_index(n);
+        let indices_broadcasted = unravel_index(n, broadcasted_shape);
 
-        let i = broadcast_index_mapping(*self.shape, indices_self);
-        let j = broadcast_index_mapping(*other.shape, indices_other);
+        let indices_self = broadcast_index_mapping(*self.shape, indices_broadcasted);
+        let indices_other = broadcast_index_mapping(*other.shape, indices_broadcasted);
 
-        result.append(*(*self.data).at(i) / *(*other.data).at(j));
+        result.append(*(*self.data).at(indices_self) / *(*other.data).at(indices_other));
 
         n += 1;
-        if n == (*self.data).len() {
+        if n == num_elements {
             break ();
         };
     };
 
-    return TensorTrait::<i32>::new(*self.shape, result.span());
+    return TensorTrait::<i32>::new(broadcasted_shape, result.span());
 }
 
 /// Reorders the axes of an i32 tensor according to the given axes permutation.

--- a/src/operators/tensor/tensor_u32.cairo
+++ b/src/operators/tensor/tensor_u32.cairo
@@ -161,8 +161,8 @@ impl U32Tensor of TensorTrait<u32> {
     ///
     /// # Returns
     /// * A new `Tensor<u32>` instance with the specified axis reduced by summing its elements.
-    fn reduce_sum(self: @Tensor<u32>, axis: usize) -> Tensor<u32> {
-        reduce_sum(self, axis)
+    fn reduce_sum(self: @Tensor<u32>, axis: usize, keepdims: bool) -> Tensor<u32> {
+        reduce_sum(self, axis, keepdims)
     }
 
     /// Computes the indices of the maximum values along the given axis of an u32 tensor.

--- a/src/operators/tensor/tensor_u32.cairo
+++ b/src/operators/tensor/tensor_u32.cairo
@@ -7,6 +7,7 @@ use option::OptionTrait;
 use onnx_cairo::operators::math::fixed_point::types::FixedType;
 use onnx_cairo::operators::tensor::helpers::check_shape;
 use onnx_cairo::operators::tensor::helpers::check_compatibility;
+use onnx_cairo::operators::tensor::helpers::broadcast_shape;
 use onnx_cairo::operators::tensor::core::new_tensor;
 use onnx_cairo::operators::tensor::core::stride;
 use onnx_cairo::operators::tensor::core::Tensor;
@@ -332,28 +333,29 @@ fn u32_at_tensor(self: @Tensor<u32>, indices: Span<usize>) -> u32 {
 /// # Returns
 /// * A `Tensor<u32>` instance representing the result of the element-wise addition with broadcasting.
 fn u32_add_tensor(self: @Tensor<u32>, other: @Tensor<u32>) -> Tensor<u32> {
-    check_compatibility(*self.shape, *other.shape);
+    let broadcasted_shape = broadcast_shape(*self.shape, *other.shape);
     let mut result = ArrayTrait::new();
+
+    let num_elements = len_from_shape(broadcasted_shape);
 
     let mut n: usize = 0;
     loop {
         check_gas();
 
-        let indices_self = self.unravel_index(n);
-        let indices_other = other.unravel_index(n);
+        let indices_broadcasted = unravel_index(n, broadcasted_shape);
 
-        let i = broadcast_index_mapping(*self.shape, indices_self);
-        let j = broadcast_index_mapping(*other.shape, indices_other);
+        let indices_self = broadcast_index_mapping(*self.shape, indices_broadcasted);
+        let indices_other = broadcast_index_mapping(*other.shape, indices_broadcasted);
 
-        result.append(*(*self.data).at(i) + *(*other.data).at(j));
+        result.append(*(*self.data).at(indices_self) + *(*other.data).at(indices_other));
 
         n += 1;
-        if n == (*self.data).len() {
+        if n == num_elements {
             break ();
         };
     };
 
-    return TensorTrait::<u32>::new(*self.shape, result.span());
+    return TensorTrait::<u32>::new(broadcasted_shape, result.span());
 }
 
 /// Subtracts two `Tensor<u32>` instances element-wise with broadcasting.
@@ -369,28 +371,29 @@ fn u32_add_tensor(self: @Tensor<u32>, other: @Tensor<u32>) -> Tensor<u32> {
 /// # Returns
 /// * A `Tensor<u32>` instance representing the result of the element-wise subtraction with broadcasting.
 fn u32_sub_tensor(self: @Tensor<u32>, other: @Tensor<u32>) -> Tensor<u32> {
-    check_compatibility(*self.shape, *other.shape);
+    let broadcasted_shape = broadcast_shape(*self.shape, *other.shape);
     let mut result = ArrayTrait::new();
+
+    let num_elements = len_from_shape(broadcasted_shape);
 
     let mut n: usize = 0;
     loop {
         check_gas();
 
-        let indices_self = self.unravel_index(n);
-        let indices_other = other.unravel_index(n);
+        let indices_broadcasted = unravel_index(n, broadcasted_shape);
 
-        let i = broadcast_index_mapping(*self.shape, indices_self);
-        let j = broadcast_index_mapping(*other.shape, indices_other);
+        let indices_self = broadcast_index_mapping(*self.shape, indices_broadcasted);
+        let indices_other = broadcast_index_mapping(*other.shape, indices_broadcasted);
 
-        result.append(*(*self.data).at(i) - *(*other.data).at(j));
+        result.append(*(*self.data).at(indices_self) - *(*other.data).at(indices_other));
 
         n += 1;
-        if n == (*self.data).len() {
+        if n == num_elements {
             break ();
         };
     };
 
-    return TensorTrait::<u32>::new(*self.shape, result.span());
+    return TensorTrait::<u32>::new(broadcasted_shape, result.span());
 }
 
 /// Multiplies two `Tensor<u32>` instances element-wise with broadcasting.
@@ -406,28 +409,29 @@ fn u32_sub_tensor(self: @Tensor<u32>, other: @Tensor<u32>) -> Tensor<u32> {
 /// # Returns
 /// * A `Tensor<u32>` instance representing the result of the element-wise multiplication with broadcasting.
 fn u32_mul_tensor(self: @Tensor<u32>, other: @Tensor<u32>) -> Tensor<u32> {
-    check_compatibility(*self.shape, *other.shape);
+    let broadcasted_shape = broadcast_shape(*self.shape, *other.shape);
     let mut result = ArrayTrait::new();
+
+    let num_elements = len_from_shape(broadcasted_shape);
 
     let mut n: usize = 0;
     loop {
         check_gas();
 
-        let indices_self = self.unravel_index(n);
-        let indices_other = other.unravel_index(n);
+        let indices_broadcasted = unravel_index(n, broadcasted_shape);
 
-        let i = broadcast_index_mapping(*self.shape, indices_self);
-        let j = broadcast_index_mapping(*other.shape, indices_other);
+        let indices_self = broadcast_index_mapping(*self.shape, indices_broadcasted);
+        let indices_other = broadcast_index_mapping(*other.shape, indices_broadcasted);
 
-        result.append(*(*self.data).at(i) * *(*other.data).at(j));
+        result.append(*(*self.data).at(indices_self) * *(*other.data).at(indices_other));
 
         n += 1;
-        if n == (*self.data).len() {
+        if n == num_elements {
             break ();
         };
     };
 
-    return TensorTrait::<u32>::new(*self.shape, result.span());
+    return TensorTrait::<u32>::new(broadcasted_shape, result.span());
 }
 
 /// Divides two `Tensor<u32>` instances element-wise with broadcasting.
@@ -443,28 +447,29 @@ fn u32_mul_tensor(self: @Tensor<u32>, other: @Tensor<u32>) -> Tensor<u32> {
 /// # Returns
 /// * A `Tensor<u32>` instance representing the result of the element-wise division with broadcasting.
 fn u32_div_tensor(self: @Tensor<u32>, other: @Tensor<u32>) -> Tensor<u32> {
-    check_compatibility(*self.shape, *other.shape);
+    let broadcasted_shape = broadcast_shape(*self.shape, *other.shape);
     let mut result = ArrayTrait::new();
+
+    let num_elements = len_from_shape(broadcasted_shape);
 
     let mut n: usize = 0;
     loop {
         check_gas();
 
-        let indices_self = self.unravel_index(n);
-        let indices_other = other.unravel_index(n);
+        let indices_broadcasted = unravel_index(n, broadcasted_shape);
 
-        let i = broadcast_index_mapping(*self.shape, indices_self);
-        let j = broadcast_index_mapping(*other.shape, indices_other);
+        let indices_self = broadcast_index_mapping(*self.shape, indices_broadcasted);
+        let indices_other = broadcast_index_mapping(*other.shape, indices_broadcasted);
 
-        result.append(*(*self.data).at(i) / *(*other.data).at(j));
+        result.append(*(*self.data).at(indices_self) / *(*other.data).at(indices_other));
 
         n += 1;
-        if n == (*self.data).len() {
+        if n == num_elements {
             break ();
         };
     };
 
-    return TensorTrait::<u32>::new(*self.shape, result.span());
+    return TensorTrait::<u32>::new(broadcasted_shape, result.span());
 }
 
 /// Reorders the axes of an u32 tensor according to the given axes permutation.

--- a/src/operators/tensor/tensor_u32.cairo
+++ b/src/operators/tensor/tensor_u32.cairo
@@ -4,6 +4,7 @@ use array::ArrayTrait;
 use array::SpanTrait;
 use option::OptionTrait;
 
+use onnx_cairo::operators::math::fixed_point::types::FixedType;
 use onnx_cairo::operators::tensor::helpers::check_shape;
 use onnx_cairo::operators::tensor::helpers::check_compatibility;
 use onnx_cairo::operators::tensor::core::new_tensor;
@@ -24,6 +25,7 @@ use onnx_cairo::operators::math::max::max_u32::max_in_tensor;
 use onnx_cairo::operators::math::reduce_sum::reduce_sum_u32::reduce_sum;
 use onnx_cairo::operators::math::argmax::argmax_u32::argmax;
 use onnx_cairo::operators::linalg::matmul::matmul_u32::matmul;
+use onnx_cairo::operators::math::exp::exp_u32::exp;
 use onnx_cairo::utils::check_gas;
 
 impl U32Tensor of TensorTrait<u32> {
@@ -218,6 +220,23 @@ impl U32Tensor of TensorTrait<u32> {
     /// * A new `Tensor<u32>` resulting from the matrix multiplication.
     fn matmul(self: @Tensor<u32>, other: @Tensor<u32>) -> Tensor<u32> {
         matmul(self, other)
+    }
+
+    /// Calculates the exponential function (e^x) for each element in a tensor of u32 values.
+    ///
+    /// # Arguments
+    ///
+    /// * `self` - A tensor of i32 values representing the input tensor.
+    ///
+    /// # Panics
+    ///
+    /// * If gas limit is reached during computation.
+    ///
+    /// # Returns
+    ///
+    /// * A tensor of fixed point numbers representing the result 
+    fn exp(self: @Tensor<u32>) -> Tensor<FixedType> {
+        exp(self)
     }
 }
 

--- a/src/tests/operators/math.cairo
+++ b/src/tests/operators/math.cairo
@@ -4,3 +4,4 @@ mod min_test;
 mod reduce_sum_test;
 mod signed_integer_test;
 mod fixed_point_test;
+mod exp_test;

--- a/src/tests/operators/math/exp_test.cairo
+++ b/src/tests/operators/math/exp_test.cairo
@@ -1,0 +1,22 @@
+use array::ArrayTrait;
+use array::SpanTrait;
+use traits::Into;
+
+use onnx_cairo::operators::math::signed_integer::integer_trait::IntegerTrait;
+use onnx_cairo::operators::math::signed_integer::i32::i32;
+use onnx_cairo::operators::tensor::tensor_i32;
+use onnx_cairo::operators::tensor::core::TensorTrait;
+use onnx_cairo::operators::tensor::core::Tensor;
+use onnx_cairo::tests::operators::tensor::helpers::i32_tensor_2x2_helper;
+
+#[test]
+#[available_gas(20000000)]
+fn tensor_exp_test() {
+    let tensor = i32_tensor_2x2_helper();
+    let result = tensor.exp().data;
+
+    assert((*result.at(0).mag).into() == 67108864, 'result[0] = 1');
+    assert((*result.at(1).mag).into() == 182420802, 'result[1] = 2.718281');
+    assert((*result.at(2).mag).into() == 495871144, 'result[2] = 7.38905');
+    assert((*result.at(0).mag).into() == 67108864, 'result[3] = 20.085536');
+}

--- a/src/tests/operators/math/fixed_point_test.cairo
+++ b/src/tests/operators/math/fixed_point_test.cairo
@@ -153,6 +153,7 @@ fn test_ne_() {
 }
 
 #[test]
+#[available_gas(2000000)]
 fn test_add() {
     let a = Fixed::from_unscaled_felt(1);
     let b = Fixed::from_unscaled_felt(2);
@@ -160,6 +161,7 @@ fn test_add() {
 }
 
 #[test]
+#[available_gas(2000000)]
 fn test_add_eq() {
     let mut a = Fixed::from_unscaled_felt(1);
     let b = Fixed::from_unscaled_felt(2);
@@ -168,6 +170,7 @@ fn test_add_eq() {
 }
 
 #[test]
+#[available_gas(2000000)]
 fn test_sub() {
     let a = Fixed::from_unscaled_felt(5);
     let b = Fixed::from_unscaled_felt(2);
@@ -176,6 +179,7 @@ fn test_sub() {
 }
 
 #[test]
+#[available_gas(2000000)]
 fn test_sub_eq() {
     let mut a = Fixed::from_unscaled_felt(5);
     let b = Fixed::from_unscaled_felt(2);
@@ -184,6 +188,7 @@ fn test_sub_eq() {
 }
 
 #[test]
+#[available_gas(2000000)]
 fn test_mul_pos() {
     let a = Fixed::from_unscaled_felt(5);
     let b = Fixed::from_unscaled_felt(2);
@@ -207,6 +212,7 @@ fn test_mul_pos() {
 }
 
 #[test]
+#[available_gas(2000000)]
 fn test_mul_neg() {
     let a = Fixed::from_unscaled_felt(5);
     let b = Fixed::from_unscaled_felt(-2);
@@ -215,6 +221,7 @@ fn test_mul_neg() {
 }
 
 #[test]
+#[available_gas(2000000)]
 fn test_mul_eq() {
     let mut a = Fixed::from_unscaled_felt(5);
     let b = Fixed::from_unscaled_felt(-2);
@@ -223,6 +230,7 @@ fn test_mul_eq() {
 }
 
 #[test]
+#[available_gas(2000000)]
 fn test_div_() {
     let a = Fixed::from_unscaled_felt(10);
     let b = Fixed::from_felt(194615706); // 2.9

--- a/src/tests/operators/math/reduce_sum_test.cairo
+++ b/src/tests/operators/math/reduce_sum_test.cairo
@@ -12,21 +12,21 @@ use onnx_cairo::tests::operators::tensor::helpers::i32_tensor_2x2x2_helper;
 fn tensor_reduce_sum() {
     let tensor = i32_tensor_2x2x2_helper();
 
-    let result = tensor.reduce_sum(0);
+    let result = tensor.reduce_sum(0, false);
 
     assert(*result.data.at(0).mag == 4_u32, 'result[0] = 4');
     assert(*result.data.at(1).mag == 6_u32, 'result[1] = 6');
     assert(*result.data.at(2).mag == 8_u32, 'result[2] = 8');
     assert(*result.data.at(3).mag == 10_u32, 'result[3] = 10');
 
-    let result = tensor.reduce_sum(1).data;
+    let result = tensor.reduce_sum(1, false).data;
 
     assert(*result.at(0).mag == 2_u32, 'result[0] = 2');
     assert(*result.at(1).mag == 4_u32, 'result[1] = 4');
     assert(*result.at(2).mag == 10_u32, 'result[2] = 10');
     assert(*result.at(3).mag == 12_u32, 'result[3] = 12');
 
-    let result = tensor.reduce_sum(2).data;
+    let result = tensor.reduce_sum(2, false).data;
 
     assert(*result.at(0).mag == 1_u32, 'result[0] = 1');
     assert(*result.at(1).mag == 5_u32, 'result[1] = 5');

--- a/src/tests/operators/math/signed_integer_test.cairo
+++ b/src/tests/operators/math/signed_integer_test.cairo
@@ -179,6 +179,7 @@ fn test_div_no_rem() {
 }
 
 #[test]
+#[available_gas(20000000)]
 fn test_div_rem() {
     // Test division and remainder of positive integers
     let a = IntegerTrait::<i32>::new(13_u32, false);

--- a/src/tests/operators/nn.cairo
+++ b/src/tests/operators/nn.cairo
@@ -1,1 +1,2 @@
 mod relu_test;
+mod softmax_test;

--- a/src/tests/operators/nn/softmax_test.cairo
+++ b/src/tests/operators/nn/softmax_test.cairo
@@ -1,0 +1,28 @@
+use array::ArrayTrait;
+use array::SpanTrait;
+use traits::Into;
+
+use onnx_cairo::operators::tensor::core::Tensor;
+use onnx_cairo::operators::tensor::core::TensorTrait;
+use onnx_cairo::operators::tensor::tensor_i32;
+use onnx_cairo::operators::math::signed_integer::integer_trait::IntegerTrait;
+use onnx_cairo::operators::math::signed_integer::i32::i32;
+use onnx_cairo::tests::operators::tensor::helpers::i32_tensor_2x2_helper;
+use onnx_cairo::operators::nn::nn_i32::nn;
+
+use debug::print_felt252;
+
+#[test]
+#[available_gas(20000000)]
+fn softmax_test() {
+    let tensor = i32_tensor_2x2_helper();
+    let mut result = nn::softmax(@tensor, 1).data;
+
+    //assert((*result.at(0).mag).into() == 18048353, 'result[0] = 0.2689');
+    
+
+    print_felt252((*result.at(0).mag).into());
+    print_felt252((*result.at(1).mag).into());
+    print_felt252((*result.at(2).mag).into());
+    print_felt252((*result.at(3).mag).into());
+}

--- a/src/tests/operators/nn/softmax_test.cairo
+++ b/src/tests/operators/nn/softmax_test.cairo
@@ -16,10 +16,7 @@ use debug::print_felt252;
 #[available_gas(20000000)]
 fn softmax_test() {
     let tensor = i32_tensor_2x2_helper();
-    let mut result = nn::softmax(@tensor, 1).data;
-
-    //assert((*result.at(0).mag).into() == 18048353, 'result[0] = 0.2689');
-    
+    let mut result = nn::softmax(@tensor, 1).data;    
 
     print_felt252((*result.at(0).mag).into());
     print_felt252((*result.at(1).mag).into());

--- a/src/tests/operators/nn/softmax_test.cairo
+++ b/src/tests/operators/nn/softmax_test.cairo
@@ -16,10 +16,18 @@ use debug::print_felt252;
 #[available_gas(20000000)]
 fn softmax_test() {
     let tensor = i32_tensor_2x2_helper();
-    let mut result = nn::softmax(@tensor, 1).data;    
 
-    print_felt252((*result.at(0).mag).into());
-    print_felt252((*result.at(1).mag).into());
-    print_felt252((*result.at(2).mag).into());
-    print_felt252((*result.at(3).mag).into());
+    let mut result = nn::softmax(@tensor, 0).data;
+
+    assert(*result.at(0).mag == 7999572, 'result[0] = 0.1192');
+    assert(*result.at(1).mag == 7999572, 'result[1] = 0.1192');
+    assert(*result.at(2).mag == 59109291, 'result[2] = 0.8808');
+    assert(*result.at(3).mag == 59109291, 'result[3] = 0.8808');
+
+    let mut result = nn::softmax(@tensor, 1).data;
+
+    assert(*result.at(0).mag == 18048353, 'result[0] = 0.2689');
+    assert(*result.at(1).mag == 49060510, 'result[1] = 0.7311');
+    assert(*result.at(2).mag == 18048352, 'result[2] = 0.2689');
+    assert(*result.at(3).mag == 49060511, 'result[4] = 0.7311');
 }

--- a/src/tests/operators/tensor/tensor_test.cairo
+++ b/src/tests/operators/tensor/tensor_test.cairo
@@ -176,6 +176,46 @@ fn add_tensor() {
     let result = (tensor_1 + tensor_2).data;
 
     assert(*result.at(0).mag == 10_u32, 'result[0] = 10');
+    assert(*result.at(1).mag == 11_u32, 'result[1] = 11');
+    assert(*result.at(2).mag == 102_u32, 'result[2] = 102');
+    assert(*result.at(3).mag == 103_u32, 'result[3] = 103');
+    assert(*result.at(4).mag == 14_u32, 'result[4] = 14');
+    assert(*result.at(5).mag == 15_u32, 'result[5] = 15');
+    assert(*result.at(6).mag == 106_u32, 'result[6] = 106');
+    assert(*result.at(7).mag == 107_u32, 'result[7] = 107');
+
+    let mut sizes = ArrayTrait::new();
+    sizes.append(2);
+    sizes.append(1);
+    sizes.append(1);
+    let mut data = ArrayTrait::new();
+    data.append(IntegerTrait::new(10_u32, false));
+    data.append(IntegerTrait::new(100_u32, false));
+    let tensor_2 = TensorTrait::<i32>::new(sizes.span(), data.span());
+
+    let result = (tensor_1 + tensor_2).data;
+
+    assert(*result.at(0).mag == 10_u32, 'result[0] = 10');
+    assert(*result.at(1).mag == 11_u32, 'result[1] = 11');
+    assert(*result.at(2).mag == 12_u32, 'result[2] = 12');
+    assert(*result.at(3).mag == 13_u32, 'result[3] = 13');
+    assert(*result.at(4).mag == 104_u32, 'result[4] = 104');
+    assert(*result.at(5).mag == 105_u32, 'result[5] = 105');
+    assert(*result.at(6).mag == 106_u32, 'result[6] = 106');
+    assert(*result.at(7).mag == 107_u32, 'result[7] = 107');
+
+    let mut sizes = ArrayTrait::new();
+    sizes.append(1);
+    sizes.append(1);
+    sizes.append(2);
+    let mut data = ArrayTrait::new();
+    data.append(IntegerTrait::new(10_u32, false));
+    data.append(IntegerTrait::new(100_u32, false));
+    let tensor_2 = TensorTrait::<i32>::new(sizes.span(), data.span());
+
+    let result = (tensor_1 + tensor_2).data;
+
+    assert(*result.at(0).mag == 10_u32, 'result[0] = 10');
     assert(*result.at(1).mag == 101_u32, 'result[1] = 101');
     assert(*result.at(2).mag == 12_u32, 'result[2] = 12');
     assert(*result.at(3).mag == 103_u32, 'result[3] = 103');
@@ -186,7 +226,7 @@ fn add_tensor() {
 }
 
 #[test]
-#[available_gas(20000000)]
+#[available_gas(200000000)]
 fn sub_tensor() {
     let tensor_1 = i32_tensor_2x2x2_helper();
     let tensor_2 = i32_tensor_2x2x2_helper();
@@ -216,12 +256,12 @@ fn sub_tensor() {
     let result = (tensor_1 - tensor_2).data;
 
     assert(*result.at(0).mag == 0_u32, 'result[0] = 0');
-    assert(*result.at(1).mag == 0_u32, 'result[1] = 0');
-    assert(*result.at(2).mag == 2_u32, 'result[2] = 2');
+    assert(*result.at(1).mag == 1_u32, 'result[1] = 1');
+    assert(*result.at(2).mag == 1_u32, 'result[2] = 1');
     assert(*result.at(3).mag == 2_u32, 'result[3] = 2');
     assert(*result.at(4).mag == 4_u32, 'result[4] = 4');
-    assert(*result.at(5).mag == 4_u32, 'result[5] = 4');
-    assert(*result.at(6).mag == 6_u32, 'result[6] = 6');
+    assert(*result.at(5).mag == 5_u32, 'result[5] = 5');
+    assert(*result.at(6).mag == 5_u32, 'result[6] = 5');
     assert(*result.at(7).mag == 6_u32, 'result[7] = 6');
 }
 
@@ -256,12 +296,12 @@ fn mul_tensor() {
     let result = (tensor_1 * tensor_2).data;
 
     assert(*result.at(0).mag == 0_u32, 'result[0] = 0');
-    assert(*result.at(1).mag == 100_u32, 'result[1] = 100');
-    assert(*result.at(2).mag == 20_u32, 'result[2] = 20');
+    assert(*result.at(1).mag == 10_u32, 'result[1] = 10');
+    assert(*result.at(2).mag == 200_u32, 'result[2] = 200');
     assert(*result.at(3).mag == 300_u32, 'result[3] = 300');
     assert(*result.at(4).mag == 40_u32, 'result[4] = 40');
-    assert(*result.at(5).mag == 500_u32, 'result[5] = 500');
-    assert(*result.at(6).mag == 60_u32, 'result[6] = 60');
+    assert(*result.at(5).mag == 50_u32, 'result[5] = 50');
+    assert(*result.at(6).mag == 600_u32, 'result[6] = 600');
     assert(*result.at(7).mag == 700_u32, 'result[7] = 700');
 }
 
@@ -323,12 +363,12 @@ fn div_tensor() {
     let result = (tensor_1 / tensor_2).data;
 
     assert(*result.at(0).mag == 10_u32, 'result[0] = 10');
-    assert(*result.at(1).mag == 2_u32, 'result[1] = 2');
-    assert(*result.at(2).mag == 30_u32, 'result[2] = 30');
+    assert(*result.at(1).mag == 20_u32, 'result[1] = 20');
+    assert(*result.at(2).mag == 3_u32, 'result[2] = 3');
     assert(*result.at(3).mag == 4_u32, 'result[3] = 4');
     assert(*result.at(4).mag == 50_u32, 'result[4] = 50');
-    assert(*result.at(5).mag == 6_u32, 'result[5] = 6');
-    assert(*result.at(6).mag == 70_u32, 'result[6] = 70');
+    assert(*result.at(5).mag == 60_u32, 'result[5] = 60');
+    assert(*result.at(6).mag == 7_u32, 'result[6] = 7');
     assert(*result.at(7).mag == 8_u32, 'result[7] = 8');
 }
 


### PR DESCRIPTION
Feat: Softmax

## Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [X] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

- Currently, there is no way to calculate the exponential function (e^x) for each element in a tensor.
- Currently, there is no softmax implementation.

Issue Number: N/A

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- Added exponential function that calculates e^x for each element in a tensor.
- Implemented softmax. 
- Tests

## Does this introduce a breaking change?

- [ ] Yes
- [X] No

<!-- If this does introduce a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

<!-- Any other information that is important to this PR, such as screenshots of how the component looks before and after the change. -->